### PR TITLE
Enhancement: Replaced date parsing with \DateTime and changed the prognosis into departure/arrival

### DIFF
--- a/lib/Transport/API.php
+++ b/lib/Transport/API.php
@@ -35,7 +35,8 @@ class API
      */
     protected $lang;
 
-    public function __construct(Browser $browser = null, $lang = 'EN') {
+    public function __construct(Browser $browser = null, $lang = 'EN')
+    {
         $this->browser = $browser ?: new Browser();
         $this->lang = $lang;
     }
@@ -43,7 +44,8 @@ class API
     /**
      * @return Buzz\Message\Response
      */
-    public function sendQuery(Query $query) {
+    public function sendQuery(Query $query)
+    {
 
         $headers = array();
         $headers[] = 'User-Agent: SBBMobile/4.2 CFNetwork/485.13.9 Darwin/11.0.0';
@@ -118,7 +120,7 @@ class API
         // fix broken JSON
         $content = $response->getContent();
         $content = preg_replace('/(\w+) ?:/i', '"\1":', $content);
-               
+
         // parse result
         $result = json_decode($content);
 
@@ -157,12 +159,12 @@ class API
         // and wrap it accordingly if time goes over midnight
         $journeys = array();
         $prevTime = time();
-        $date = date('Y-m-d', strtotime($query->date));
+        $date = $query->date;
         if ($result->STBRes->JourneyList->STBJourney) {
             foreach ($result->STBRes->JourneyList->STBJourney as $journey) {
                 $curTime = strtotime((string) $journey->MainStop->BasicStop->Dep->Time);
                 if ($prevTime > $curTime) { // we passed midnight
-                    $date = date('Y-m-d', strtotime("$date +1day"));
+                    $date->add(new \DateInterval('P1D'));
                 }
                 $journeys[] = Entity\Schedule\StationBoardJourney::createFromXml($journey, $date);
                 $prevTime = $curTime;

--- a/lib/Transport/Entity/Schedule/Connection.php
+++ b/lib/Transport/Entity/Schedule/Connection.php
@@ -29,7 +29,10 @@ class Connection
         if (!$obj) {
             $obj = new Connection();
         }
-        $date = date('Y-m-d', strtotime((string) $xml->Overview->Date));
+        $date = \DateTime::createFromFormat('Ymd', (string) $xml->Overview->Date, new \DateTimeZone('Europe/Zurich'));
+        $date->setTimezone(new \DateTimeZone('Europe/Zurich'));
+        $date->setTime(0, 0, 0);
+
         $obj->from = Entity\Schedule\Stop::createFromXml($xml->Overview->Departure->BasicStop, $date);
         $obj->to = Entity\Schedule\Stop::createFromXml($xml->Overview->Arrival->BasicStop, $date);
 

--- a/lib/Transport/Entity/Schedule/Prognosis.php
+++ b/lib/Transport/Entity/Schedule/Prognosis.php
@@ -5,11 +5,12 @@ namespace Transport\Entity\Schedule;
 class Prognosis
 {
     public $platform;
-    public $time;
+    public $arrival;
+    public $departure;
     public $capacity1st;
     public $capacity2nd;
 
-    static public function createFromXml(\SimpleXMLElement $xml, Prognosis $obj = null)
+    static public function createFromXml(\SimpleXMLElement $xml, \DateTime $date, Prognosis $obj = null)
     {
         if (!$obj) {
             $obj = new Prognosis();
@@ -17,10 +18,10 @@ class Prognosis
 
         if ($xml->Arr) {
             if ($xml->Arr->Platform) {
-                $obj->platform = Stop::parseTime((string) $xml->Arr->Platform->Text);
+                $obj->platform = (string) $xml->Arr->Platform->Text;
             }
             if ($xml->Arr->Time) {
-                $obj->time = (string) $xml->Arr->Time;
+                $obj->arrival = Stop::calculateDateTime((string) $xml->Arr->Time, $date)->format(\DateTime::ISO8601);
             }
         }
 
@@ -29,7 +30,7 @@ class Prognosis
                 $obj->platform = (string) $xml->Dep->Platform->Text;
             }
             if ($xml->Dep->Time) {
-                $obj->time = Stop::parseTime((string) $xml->Dep->Time);
+                $obj->departure = Stop::calculateDateTime((string) $xml->Dep->Time, $date)->format(\DateTime::ISO8601);
             }
         }
 

--- a/lib/Transport/Entity/Schedule/StationBoardJourney.php
+++ b/lib/Transport/Entity/Schedule/StationBoardJourney.php
@@ -43,7 +43,7 @@ class StationBoardJourney
      * @param   StationBoardJourney $obj    An optional existing journey to overwrite
      * @return  StationBoardJourney
      */
-    static public function createFromXml(\SimpleXMLElement $xml, $date, StationBoardJourney $obj = null)
+    static public function createFromXml(\SimpleXMLElement $xml, \DateTime $date, StationBoardJourney $obj = null)
     {
         if (!$obj) {
             $obj = new StationBoardJourney();
@@ -53,7 +53,7 @@ class StationBoardJourney
 
         // TODO: get attributes
         foreach ($xml->JourneyAttributeList->JourneyAttribute AS $journeyAttribute) {
-        
+
             switch ($journeyAttribute->Attribute['type']) {
                 case 'NAME':
                     $obj->name = (string) $journeyAttribute->Attribute->AttributeVariant->Text;

--- a/lib/Transport/Entity/Schedule/StationBoardQuery.php
+++ b/lib/Transport/Entity/Schedule/StationBoardQuery.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Transport\Entity\Schedule;
 
@@ -21,11 +21,14 @@ class StationBoardQuery extends Query
 
     public $transportations = array('all');
 
-    public function __construct(Station $station, $date = null)
+    public function __construct(Station $station, \DateTime $date = null)
     {
         $this->station = $station;
 
-        $this->date = $date ?: date('c');
+        if (!($date instanceof \DateTime)) {
+            $date = new \DateTime('now', new \DateTimeZone('Europe/Zurich'));
+        }
+        $this->date = $date;
     }
 
     public function toXml()
@@ -36,13 +39,13 @@ class StationBoardQuery extends Query
 
         $board->addAttribute('boardType', $this->boardType);
         $board->addAttribute('maxJourneys', $this->maxJourneys);
-        $board->addChild('Time', date('H:i', strtotime($this->date)));
+        $board->addChild('Time', $this->date->format('H:i'));
 
         $period = $board->addChild('Period');
         $dateBegin = $period->addChild('DateBegin');
-        $dateBegin->addChild('Date', date('Ymd', strtotime($this->date)));
+        $dateBegin->addChild('Date', $this->date->format('Ymd'));
         $dateEnd = $period->addChild('DateEnd');
-        $dateEnd->addChild('Date', date('Ymd', strtotime($this->date)));
+        $dateEnd->addChild('Date', $this->date->format('Ymd'));
 
         $tableStation = $board->addChild('TableStation');
         $tableStation->addAttribute('externalId', $this->station->id);
@@ -50,4 +53,5 @@ class StationBoardQuery extends Query
 
         return $request->asXML();
     }
+
 }

--- a/lib/Transport/Entity/Schedule/Stop.php
+++ b/lib/Transport/Entity/Schedule/Stop.php
@@ -18,52 +18,56 @@ class Stop
 
     public $prognosis;
 
-    public function __construct() {
-        $this->prognosis = new Prognosis(); 
+    public function __construct()
+    {
+        $this->prognosis = new Prognosis();
     }
 
     /**
      * Calculates a datetime by parsing the time and date given
      *
-     * @param   string  $time       The time to parse, can contain an optional offset prefix (e.g., "02d")
-     * @param   string  $date       The date
-     * @return  string  The parsed time in ISO format
+     * @param   string		$time		The time to parse, can contain an optional offset prefix (e.g., "02d")
+     * @param   \DateTime	$date       The date
+     * @return  \DateTime  The parsed time in ISO format
      */
-    static public function calculateDateTime($time, $date)
+    static public function calculateDateTime($time, \DateTime $date)
     {
+        $offset = 0;
         if (substr($time, 2, 1) == 'd') {
             $offset = substr($time, 0, 2);
             $time = substr($time, 3);
-            $date = date('Y-m-d', strtotime("$date +$offset days"));
         }
+        // Prevent changing the reference
+        $date = clone $date;
+        $date->add(new \DateInterval('P' . $offset . 'D'));
+        $timeObj = \DateTime::createFromFormat('H:i:s', $time, $date->getTimezone());
+        if ($timeObj === false) {
+            $timeObj = \DateTime::createFromFormat('H:i', $time, $date->getTimezone());
+        }
+        $date->setTime($timeObj->format('H'), $timeObj->format('i'), $timeObj->format('s'));
 
-        return date('c', strtotime("$date $time"));
+        return $date;
     }
 
-    static public function parseTime($time)
-    {
-        if (substr($time, 2, 1) == 'd') {
-            return substr($time, 3);
-        }
-        return $time;
-    }
-
-    static public function createFromXml(\SimpleXMLElement $xml, $date, Stop $obj = null)
+    static public function createFromXml(\SimpleXMLElement $xml, \DateTime $date, Stop $obj = null)
     {
         if (!$obj) {
             $obj = new Stop();
         }
 
+        $dateTime = null;
         $obj->station = Entity\Location\Station::createFromXml($xml->Station);
         if ($xml->Arr) {
-            $obj->arrival = self::calculateDateTime((string) $xml->Arr->Time, $date);
+            $dateTime = self::calculateDateTime((string) $xml->Arr->Time, $date);
+            $obj->arrival = $dateTime->format(\DateTime::ISO8601);
             $obj->platform = trim((string) $xml->Arr->Platform->Text);
         }
         if ($xml->Dep) {
-            $obj->departure = self::calculateDateTime((string) $xml->Dep->Time, $date);
+            $dateTime = self::calculateDateTime((string) $xml->Dep->Time, $date);
+            $obj->departure = $dateTime->format(\DateTime::ISO8601);
             $obj->platform = trim((string) $xml->Dep->Platform->Text);
         }
-        $obj->prognosis = Prognosis::createFromXml($xml->StopPrognosis);
+        $obj->prognosis = Prognosis::createFromXml($xml->StopPrognosis, $dateTime, null);
 
         return $obj;
     }

--- a/test/Transport/Test/APITest.php
+++ b/test/Transport/Test/APITest.php
@@ -21,22 +21,22 @@ class APITest extends \PHPUnit_Framework_TestCase
     {
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__ . '/../../fixtures/location.xml'));
-    
+
         $this->browser->expects($this->once())
             ->method('post')
             ->with(
                 $this->equalTo('http://xmlfahrplan.sbb.ch/bin/extxml.exe/'),
                 $this->equalTo(array(
-                    'User-Agent: SBBMobile/4.2 CFNetwork/485.13.9 Darwin/11.0.0',
-                    'Accept: application/xml',
-                    'Content-Type: application/xml'
+                        'User-Agent: SBBMobile/4.2 CFNetwork/485.13.9 Darwin/11.0.0',
+                        'Accept: application/xml',
+                        'Content-Type: application/xml'
                 )),
                 $this->equalTo('<?xml version="1.0" encoding="utf-8"?>
 <ReqC lang="EN" prod="iPhone3.1" ver="2.3" accessId="MJXZ841ZfsmqqmSymWhBPy5dMNoqoGsHInHbWJQ5PTUZOJ1rLTkn8vVZOZDFfSe"><LocValReq id="from" sMode="1"><ReqLoc match="Zürich" type="ALLTYPE"/></LocValReq><LocValReq id="to" sMode="1"><ReqLoc match="Bern" type="ALLTYPE"/></LocValReq></ReqC>
 ')
             )
             ->will($this->returnValue($response));
-        
+
         $locations = $this->api->findLocations(new LocationQuery(array('from' => 'Zürich', 'to' => 'Bern')));
 
         $this->assertEquals(2, count($locations));
@@ -60,9 +60,9 @@ class APITest extends \PHPUnit_Framework_TestCase
             ->with(
                 $this->equalTo('http://xmlfahrplan.sbb.ch/bin/extxml.exe/'),
                 $this->equalTo(array(
-                    'User-Agent: SBBMobile/4.2 CFNetwork/485.13.9 Darwin/11.0.0',
-                    'Accept: application/xml',
-                    'Content-Type: application/xml'
+                        'User-Agent: SBBMobile/4.2 CFNetwork/485.13.9 Darwin/11.0.0',
+                        'Accept: application/xml',
+                        'Content-Type: application/xml'
                 )),
                 $this->equalTo('<?xml version="1.0" encoding="utf-8"?>
 <ReqC lang="EN" prod="iPhone3.1" ver="2.3" accessId="MJXZ841ZfsmqqmSymWhBPy5dMNoqoGsHInHbWJQ5PTUZOJ1rLTkn8vVZOZDFfSe"><STBReq boardType="DEP" maxJourneys="40"><Time>23:55</Time><Period><DateBegin><Date>20120213</Date></DateBegin><DateEnd><Date>20120213</Date></DateEnd></Period><TableStation externalId="008591052"/><ProductFilter>1111111111111111</ProductFilter></STBReq></ReqC>
@@ -71,11 +71,11 @@ class APITest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($response));
 
         $station = new Station('008591052'); // Zürich, Bäckeranlage
-        $journeys = $this->api->getStationBoard(new StationBoardQuery($station, '2012-02-13T23:55:00+01:00'));
+        $journeys = $this->api->getStationBoard(new StationBoardQuery($station, \DateTime::createFromFormat(\DateTime::ISO8601, '2012-02-13T23:55:00+01:00')));
 
         $this->assertEquals(3, count($journeys));
-        $this->assertEquals('2012-02-13T23:57:00+01:00', $journeys[0]->stop->departure);
-        $this->assertEquals('2012-02-13T23:58:00+01:00', $journeys[1]->stop->departure);
-        $this->assertEquals('2012-02-14T04:41:00+01:00', $journeys[2]->stop->departure);
+        $this->assertEquals('2012-02-13T23:57:00+0100', $journeys[0]->stop->departure);
+        $this->assertEquals('2012-02-13T23:58:00+0100', $journeys[1]->stop->departure);
+        $this->assertEquals('2012-02-14T04:41:00+0100', $journeys[2]->stop->departure);
     }
 }

--- a/test/Transport/Test/Entity/Schedule/ConnectionDelayTest.php
+++ b/test/Transport/Test/Entity/Schedule/ConnectionDelayTest.php
@@ -10,10 +10,10 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
     protected function getConnection()
     {   
         $from = new Entity\Schedule\Stop();
-        $from->departure = '2012-01-16T16:10:00+01:00';
+        $from->departure = '2012-01-16T16:10:00+0100';
         $from->platform = '3';
         $prognosis = new Entity\Schedule\Prognosis();
-            $prognosis->time = '16:18:00';
+            $prognosis->departure = '2012-01-16T16:18:00+0100';
             $prognosis->capacity1st = '1';
             $prognosis->capacity2nd = '1';
         $from->prognosis = $prognosis;
@@ -28,7 +28,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
         $from->station = $station;
 
         $to = new Entity\Schedule\Stop();
-        $to->arrival = '2012-01-16T16:49:00+01:00';
+        $to->arrival = '2012-01-16T16:49:00+0100';
         $to->platform = '7';
         $station = new Entity\Location\Station();
             $station->name = "Zug";
@@ -42,7 +42,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
 
 
         $section1From = new Entity\Schedule\Stop();
-        $section1From->departure = '2012-01-16T16:06:00+01:00';
+        $section1From->departure = '2012-01-16T16:06:00+0100';
         $station = new Entity\Location\Station();
             $station->name = "Zürich, Bahnhof Altstetten";
             $station->id = "000103022";
@@ -54,7 +54,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
         $section1From->station = $station;
 
         $section1To = new Entity\Schedule\Stop();
-        $section1To->arrival = "2012-01-16T16:10:00+01:00";
+        $section1To->arrival = "2012-01-16T16:10:00+0100";
         $station = new Entity\Location\Station();
             $station->name = "Zürich Altstetten";
             $station->id = "008503001";
@@ -66,10 +66,10 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
         $section1To->station = $station;
 
         $section2From = new Entity\Schedule\Stop();
-        $section2From->departure = '2012-01-16T16:10:00+01:00';
+        $section2From->departure = '2012-01-16T16:10:00+0100';
         $section2From->platform = '3';
         $prognosis = new Entity\Schedule\Prognosis();
-            $prognosis->time = '16:18:00';
+            $prognosis->departure = '2012-01-16T16:18:00+0100';
             $prognosis->capacity1st = '1';
             $prognosis->capacity2nd = '1';
         $section2From->prognosis = $prognosis;
@@ -84,7 +84,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
         $section2From->station = $station;
 
         $section2To = new Entity\Schedule\Stop();
-        $section2To->arrival = '2012-01-16T16:49:00+01:00';
+        $section2To->arrival = '2012-01-16T16:49:00+0100';
         $section2To->platform = '7';
         $station = new Entity\Location\Station();
             $station->name = "Zug";

--- a/test/Transport/Test/Entity/Schedule/ConnectionTest.php
+++ b/test/Transport/Test/Entity/Schedule/ConnectionTest.php
@@ -10,7 +10,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
     protected function getConnection()
     {   
         $from = new Entity\Schedule\Stop();
-        $from->departure = '2012-01-31T19:14:00+01:00';
+        $from->departure = '2012-01-31T19:14:00+0100';
         $from->platform = '21/22';
         $prognosis = new Entity\Schedule\Prognosis();
         $prognosis->capacity1st = '1';
@@ -27,7 +27,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $from->station = $station;
 
         $to = new Entity\Schedule\Stop();
-        $to->arrival = '2012-01-31T19:42:00+01:00';
+        $to->arrival = '2012-01-31T19:42:00+0100';
         $to->platform = '3';
         $station = new Entity\Location\Station();
             $station->name = "Baden";

--- a/test/Transport/Test/Entity/Schedule/StationBoardJourneyTest.php
+++ b/test/Transport/Test/Entity/Schedule/StationBoardJourneyTest.php
@@ -10,7 +10,7 @@ class StationBoardJourneyTest extends \PHPUnit_Framework_TestCase
     protected function getJourney()
     {   
         $stop = new Entity\Schedule\Stop();
-        $stop->departure = '2012-03-31T23:57:00+02:00';
+        $stop->departure = '2012-03-31T23:57:00+0200';
         $prognosis = new Entity\Schedule\Prognosis();
         $prognosis->capacity1st = '-1';
         $prognosis->capacity2nd = '-1';
@@ -40,7 +40,10 @@ class StationBoardJourneyTest extends \PHPUnit_Framework_TestCase
     {
         $xml = simplexml_load_file(__DIR__ . '/../../../../fixtures/stationboard.xml');
 
-        $this->assertEquals($this->getJourney(), StationBoardJourney::createFromXml($xml->STBRes->JourneyList->STBJourney[0], '2012-03-31'));
+        $date = \DateTime::createFromFormat('Y-m-d', '2012-03-31', new \DateTimeZone('Europe/Zurich'));
+        $date->setTimezone(new \DateTimeZone('Europe/Zurich'));
+        $date->setTime(0, 0, 0);
+        $this->assertEquals($this->getJourney(), StationBoardJourney::createFromXml($xml->STBRes->JourneyList->STBJourney[0], $date));
     }
 }
 

--- a/test/Transport/Test/Entity/Schedule/StopTest.php
+++ b/test/Transport/Test/Entity/Schedule/StopTest.php
@@ -6,19 +6,31 @@ use Transport\Entity\Schedule\Stop;
 
 class StopTest extends \PHPUnit_Framework_TestCase
 {
+
+    /**
+     * @var \DateTime
+     */
+    private $date;
+
+    public function setUp()
+    {
+        $this->date = \DateTime::createFromFormat('Y-m-d', '2012-03-30', new \DateTimeZone('Europe/Zurich'));
+        $this->date->setTime(0, 0, 0);
+    }
+
     public function testParseDateTimeOffset()
     {
-        $this->assertEquals('2012-03-31T13:03:59+02:00', Stop::calculateDateTime('01d13:03:59', '2012-03-30'));
+        $this->assertEquals('2012-03-31T13:03:59+0200', Stop::calculateDateTime('01d13:03:59', $this->date)->format(\DateTime::ISO8601));
     }
 
     public function testParseDateTimeNoOffset()
     {
-        $this->assertEquals('2012-03-30T13:03:59+02:00', Stop::calculateDateTime('00d13:03:59', '2012-03-30'));
+        $this->assertEquals('2012-03-30T13:03:59+0200', Stop::calculateDateTime('00d13:03:59', $this->date)->format(\DateTime::ISO8601));
     }
 
     public function testParseDateTimeNoPrefix()
     {
-        $this->assertEquals('2012-03-30T13:03:59+02:00', Stop::calculateDateTime('13:03:59', '2012-03-30'));
+        $this->assertEquals('2012-03-30T13:03:59+0200', Stop::calculateDateTime('13:03:59', $this->date)->format(\DateTime::ISO8601));
     }
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -259,7 +259,7 @@
                     "capacity1st" : "-1",
                     "capacity2nd" : "-1",
                     "platform" : null,
-                    "time" : null
+                    "arrival" : null
                 },
                 "station" : {
                     "coordinate" : {
@@ -280,7 +280,7 @@
                     "capacity1st" : null,
                     "capacity2nd" : null,
                     "platform" : null,
-                    "time" : null
+                    "departure" : null
                 },
                 "station" : {
                     "coordinate" : {
@@ -604,9 +604,14 @@
                         <td>8</td>
                     </tr>
                     <tr>
-                        <td><code>time</code></td>
-                        <td>The estimated arrival/departure time to/from the checkpoint</td>
-                        <td>14:58:00</td>
+                        <td><code>departure</code></td>
+                        <td>The departure time prognosis to the checkpoint<br>Date format: <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a></td>
+                        <td>2012-03-31T08:58:00+02:00</td>
+                    </tr>
+                    <tr>
+                        <td><code>arrival</code></td>
+                        <td>The arrival time prognosis to the checkpoint<br>Date format: <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a></td>
+                        <td>2012-03-31T09:35:00+02:00</td>
                     </tr>
                     <tr>
                         <td><code>capacity1st</code></td>


### PR DESCRIPTION
Replaced all occurence of strtotime and date() parsing with PHP 5.3 built in class \DateTime to the
calculation and date/time passing.
The advantage using \DateTime over strtotime/date() is the hard coding of the timezone.
This makes the code more reliable against global (php.ini, server setting) timezone settings.
- Every delay will be displayed as departure/arrival property as ISO 8601 date
- Fixed bug in prognosis parsing (platform and time of arrival was mixed up).
- Fixed problem with wrong or non existing timezone. Set the timezone to 'Europe/Zurich'
