### PR TITLE
StationBoard incorrectly adds 1 day period

### DIFF
--- a/lib/Transport/API.php
+++ b/lib/Transport/API.php
@@ -158,7 +158,8 @@ class API
         // since the stationboard always lists all connections starting from now we just use the date
         // and wrap it accordingly if time goes over midnight
         $journeys = array();
-        $prevTime = time();
+        // subtract one minute because SBB also returns results for one minute in the past
+        $prevTime = time() - 60;
         $date = $query->date;
         if ($result->STBRes->JourneyList->STBJourney) {
             foreach ($result->STBRes->JourneyList->STBJourney as $journey) {


### PR DESCRIPTION
bugfix for stationboard incorrectly adds 1 day to ALL transports when le.ss than 1 minute passed since first transport departure.
