### PR TITLE
Bugfix: Added html encoding for special character in near by search

### DIFF
--- a/lib/Transport/Entity/Location/Location.php
+++ b/lib/Transport/Entity/Location/Location.php
@@ -61,7 +61,7 @@ class Location
         }
 
         if ($json->name) {
-            $obj->name = $json->name;
+            $obj->name = html_entity_decode($json->name, null, 'UTF-8');
         }
         $obj->coordinate = Coordinate::createFromJson($json);
 

--- a/lib/Transport/Entity/Schedule/ConnectionQuery.php
+++ b/lib/Transport/Entity/Schedule/ConnectionQuery.php
@@ -32,7 +32,7 @@ class ConnectionQuery extends Query
 
     public $changeExtensionPercent = 0;
 
-    public function __construct(Location $srcLocation, Location $dstLocation, $viaLocations = array(), $date = null, $time = null)
+    public function __construct(Location $srcLocation, Location $dstLocation, array $viaLocations = array(), $date = null, $time = null)
     {
         $this->srcLocation = $srcLocation;
         $this->dstLocation = $dstLocation;

--- a/test/Transport/Test/Entity/LocationFactoryTest.php
+++ b/test/Transport/Test/Entity/LocationFactoryTest.php
@@ -2,10 +2,13 @@
 
 namespace Transport\Test\Entity;
 
+use Transport\Entity\Coordinate;
 use Transport\Entity\LocationFactory;
+use Transport\Entity\Location\Station;
 
 class LocationFactoryTest extends \PHPUnit_Framework_TestCase
 {
+
     public function testCreateFromXml_Poi()
     {
         $xml = new \SimpleXMLElement('<Poi />');
@@ -29,5 +32,52 @@ class LocationFactoryTest extends \PHPUnit_Framework_TestCase
         $xml = new \SimpleXMLElement('<YouDontKnowMe />');
         $this->assertNull(LocationFactory::createFromXml($xml));
     }
-}
 
+    public function testCreateFromJson()
+    {
+        $jsonString = <<<'EOF'
+{
+    "extId": "8508489", 
+    "name": "Nummerland", 
+    "prodclass": "16",
+    "puic": "85", 
+    "urlname": "Nummerland", 
+    "x": "8382324", 
+    "y": "47003057"
+}
+EOF;
+        $station = new Station();
+        $station->name = 'Nummerland';
+        $station->id = 8508489;
+        $coordinate = new Coordinate();
+        $coordinate->type = 'WGS84';
+        $coordinate->x = 8.382324;
+        $coordinate->y = 47.003057;
+        $station->coordinate = $coordinate;
+        $this->assertEquals($station, LocationFactory::createFromJson(json_decode($jsonString)));
+    }
+
+    public function testCreateFromJsonWithUmlaute()
+    {
+        $jsonString = <<<'EOF'
+{
+    "extId": "8508489", 
+    "name": "N&#252;mmerland", 
+    "prodclass": "16",
+    "puic": "85", 
+    "urlname": "N%FCmmerland", 
+    "x": "8382324", 
+    "y": "47003057"
+}
+EOF;
+        $station = new Station();
+        $station->name = 'Nümmerland';
+        $station->id = 8508489;
+        $coordinate = new Coordinate();
+        $coordinate->type = 'WGS84';
+        $coordinate->x = 8.382324;
+        $coordinate->y = 47.003057;
+        $station->coordinate = $coordinate;
+        $this->assertEquals($station, LocationFactory::createFromJson(json_decode($jsonString)));
+    }
+}

--- a/test/fixtures/location.json
+++ b/test/fixtures/location.json
@@ -1,0 +1,25 @@
+{
+    "error": "0", 
+    "numberofstops": "2", 
+    "prods": "1023", 
+    "stops": [
+        {
+            "extId": "8508489", 
+            "name": "Kehrsiten-B&#252;rgenstock", 
+            "prodclass": "16", 
+            "puic": "85", 
+            "urlname": "Kehrsiten-B%FCrgenstock", 
+            "x": "8382324", 
+            "y": "47003057"
+        }, 
+        {
+            "extId": "8579228", 
+            "name": "B&#252;rgenstock, Hotels", 
+            "prodclass": "64", 
+            "puic": "85", 
+            "urlname": "B%FCrgenstock,%20Hotels", 
+            "x": "8386252", 
+            "y": "46997088"
+        }
+    ]
+}

--- a/test/update-fixtures.php
+++ b/test/update-fixtures.php
@@ -1,13 +1,15 @@
 <?php
 
+use Transport\Entity\Query;
 use Transport\Entity\Location\Station;
 use Transport\Entity\Location\LocationQuery;
+use Transport\Entity\Location\NearbyQuery;
 use Transport\Entity\Schedule\ConnectionQuery;
 use Transport\Entity\Schedule\StationBoardQuery;
 
 require_once 'bootstrap.php';
 
-function download($query, $file) {
+function download(Query $query, $file) {
 
     $api = new Transport\API();
 
@@ -24,6 +26,37 @@ function download($query, $file) {
     }
 }
 
+function downloadJson($url, $file) {
+
+    $browser = new Buzz\Browser();
+
+    // send request
+    $response = $browser->get($url);
+
+    // fix broken JSON
+    $content = $response->getContent();
+    $content = preg_replace('/(\w+) ?:/i', '"\1":', $content);
+
+    $filename = __DIR__ . '/fixtures/' . $file;
+    file_put_contents($filename, $content);
+
+    if (function_exists('exec')) {
+        $formatedFilename = $filename . '.formated';
+        exec('python -mjson.tool ' . escapeshellarg($filename) . ' 2>/dev/null > ' . escapeshellarg($formatedFilename));
+
+        if (!file_exists($formatedFilename)) {
+            return;
+        }
+        if (filesize($formatedFilename) !== 0) {
+            unlink($filename);
+            rename($formatedFilename, $filename);
+        } else {
+            // Do cleanup on failure
+            unlink($formatedFilename);
+        }
+    }
+}
+
 // Location
 $query = new LocationQuery(array('from' => 'Zürich', 'to' => 'Bern'));
 download($query, 'location.xml');
@@ -31,12 +64,16 @@ download($query, 'location.xml');
 // Connection
 $from = new Station('008503000');
 $to = new Station('008503504');
-$query = new ConnectionQuery($from, $to, '2012-01-31T19:10:00+01:00');
+$query = new ConnectionQuery($from, $to, array(), '2012-02-13T23:55:00+01:00');
 download($query, 'connection.xml');
 
 // Station Board
 $station = new Station('008591052'); // Zürich, Bäckeranlage
-$query = new StationBoardQuery($station, '2012-02-13T23:55:00+01:00');
+$query = new StationBoardQuery($station, \DateTime::createFromFormat(\DateTime::ISO8601, '2012-02-13T23:55:00+01:00', new \DateTimeZone('Europe/Zurich')));
 $query->maxJourneys = 3;
 download($query, 'stationboard.xml');
 
+// Close to Kehrsiten-Bürgenstock
+$nearBy = new NearbyQuery('47.002347', '8.379934', 2);
+$url = Transport\API::URL_QUERY . '?' . http_build_query($nearBy->toArray());
+downloadJson($url, 'location.json');


### PR DESCRIPTION
The following problems are solved
- Fixed issue with html entities in station name of near by seach (JSON)
- Added fixture downloader for near by json
- Added test case for API nearby search
- Added test case for Location parsing from json
- Added JSON nearby fixture
