### PR TITLE
Improvement: Extended connection limit to 30. Internaly 'more connection' search is performed

### DIFF
--- a/lib/Transport/Entity/Schedule/MoreConnectionQuery.php
+++ b/lib/Transport/Entity/Schedule/MoreConnectionQuery.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Transport\Entity\Schedule;
+
+use Transport\Entity\Query;
+use Transport\Entity\Transportations;
+use Transport\Entity\Location\Location;
+
+class MoreConnectionQuery extends Query
+{
+
+    public $connetionReference = null;
+    public $forwardCount = null;
+    public $backwardCount = null;
+
+    public function __construct($connetionReference, $forwardCount)
+    {
+        $this->connetionReference = $connetionReference;
+        $this->forwardCount = $forwardCount;
+    }
+
+    public function toXml()
+    {
+        $request = $this->createRequest();
+
+        $con = $request->addChild('ConScrReq');
+        // @TODO: Implement backward search in time $con['scrDir'] = 'B';
+        $con['scrDir'] = 'F';
+        $con['nrCons'] = $this->forwardCount;
+
+        $con->addChild('ConResCtxt', $this->connetionReference);
+
+        return $request->asXML();
+    }
+
+}

--- a/test/Transport/Test/APITest.php
+++ b/test/Transport/Test/APITest.php
@@ -25,7 +25,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $this->browser->expects($this->once())
             ->method('post')
             ->with(
-                $this->equalTo('http://xmlfahrplan.sbb.ch/bin/extxml.exe/'),
+                $this->equalTo('http://fahrplan.sbb.ch/bin/extxml.exe/'),
                 $this->equalTo(array(
                         'User-Agent: SBBMobile/4.2 CFNetwork/485.13.9 Darwin/11.0.0',
                         'Accept: application/xml',
@@ -58,7 +58,7 @@ class APITest extends \PHPUnit_Framework_TestCase
         $this->browser->expects($this->once())
             ->method('post')
             ->with(
-                $this->equalTo('http://xmlfahrplan.sbb.ch/bin/extxml.exe/'),
+                $this->equalTo('http://fahrplan.sbb.ch/bin/extxml.exe/'),
                 $this->equalTo(array(
                         'User-Agent: SBBMobile/4.2 CFNetwork/485.13.9 Darwin/11.0.0',
                         'Accept: application/xml',

--- a/web/api.php
+++ b/web/api.php
@@ -108,8 +108,9 @@ $app->get('/v1/connections', function(Request $request) use ($app) {
     $couchette = $request->get('chouchette');
     $bike = $request->get('bike');
 
-    if ($limit > 6) {
-        return new Response('Maximal value of argument `limit` is 6.', 400);
+    // Don't stress the SBB with more than 5 request (6 connection each request)
+    if ($limit > 30) {
+        return new Response('Maximal value of argument `limit` is 30.', 400);
     }
 
     // get stations


### PR DESCRIPTION
Important!!
For this pull request the query API Uri has been changed.
The change was necessary due the fact, that the xmlfahrplan API is not capable to perform a 'more
connection' requests. All the 'old' functionalities are working with the changed Uri.

This commit sets the connection limit up to 30. This is done by additionally search more
connection from a existing Connection reference.

Note: The limit of 30 is only a hard coded limit to avoid a DoS attacks via the transport API
- Changed the upper limit from 6 to 30 connection
  *\* Added possibility to search more connection based on an existing connection reference 
- Changed the SBB request URI
