### PR TITLE
only includes stops in passList if stationId is a real station, fixes #59 #60

### DIFF
--- a/lib/Transport/Entity/Schedule/Journey.php
+++ b/lib/Transport/Entity/Schedule/Journey.php
@@ -70,7 +70,7 @@ class Journey
         
         if($xml->PassList->BasicStop) {
             foreach ($xml->PassList->BasicStop AS $basicStop) {
-                if (substr($basicStop->Station['externalStationNr'],0,4) == '0085') {
+                if ($basicStop->Arr || $basicStop->Dep) {
                     $obj->passList[] = Stop::createFromXml($basicStop, $date);
                 }
             }


### PR DESCRIPTION
only stations with id starting with 0085 get included in the passList. All real stations start with these numbers. This is confirmed using the Didok-List from http://www.bav.admin.ch/dokumentation/publikationen/00475/01497/index.html.
