### PR TITLE
fixing incorrect single quote escaping in JSON

### DIFF
--- a/lib/Transport/API.php
+++ b/lib/Transport/API.php
@@ -136,6 +136,7 @@ class API
         // fix broken JSON
         $content = $response->getContent();
         $content = preg_replace('/(\w+) ?:/i', '"\1":', $content);
+        $content = str_replace("\\'", "'", $content);
 
         // parse result
         $result = json_decode($content);


### PR DESCRIPTION
Fix for a part of issue #87. What happened there is that `Browser` returns incorrectly escaped JSON.
It escapes single quotes everywhere with a backslash, which is considered an error according to JSON specification (see first answer here for clarification http://stackoverflow.com/questions/2275359/jquery-single-quote-in-json-response).

This error leads to a large number of location queries to return errors, virtually every location that has a station name with a single quote nearby.
