### PR TITLE
connections.limit: Fixed example

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -249,7 +249,7 @@
                         <td><code>limit</code></td>
                         <td>optional</td>
                         <td>1 - 6. Specifies the number of connections to return. If several connections depart at the same time they are counted as 1.</td>
-                        <td>Bern</td>
+                        <td>4</td>
                     </tr>
                     <tr>
                         <td><code>page</code></td>


### PR DESCRIPTION
connections.limit = "Bern" does not seem like a correct example. 
