### PR TITLE
Add a probability for being realtime data

### DIFF
--- a/lib/Transport/Entity/Schedule/Prognosis.php
+++ b/lib/Transport/Entity/Schedule/Prognosis.php
@@ -9,7 +9,8 @@ class Prognosis
     public $departure;
     public $capacity1st;
     public $capacity2nd;
-
+    public $realtimeProb = 0; //adds a probability for being a realtime info. 0 = no, 25 = maybe not, 75 = maybe, 100 = certainly
+    
     static public function createFromXml(\SimpleXMLElement $xml, \DateTime $date, $isArrival, Prognosis $obj = null)
     {
         if (!$obj) {
@@ -43,6 +44,9 @@ class Prognosis
         }
         if ($xml->Capacity2nd) {
             $obj->capacity2nd = (int) $xml->Capacity2nd;
+        }
+        if ($xml->Status) {
+            $obj->realtimeProb = 25;
         }
 
         return $obj;

--- a/lib/Transport/Entity/Schedule/Stop.php
+++ b/lib/Transport/Entity/Schedule/Stop.php
@@ -102,7 +102,7 @@ class Stop
         }
         if ($xml->StAttrList) {
             foreach ($xml->StAttrList->StAttr as $attr) {
-                if ($attr["code"] == "RA") {
+                if ($attr["code"] == "RA" && $attr['text'] == 'RT_BHF') {
                     $obj->prognosis->realtimeProb = 75; //maybe
                 }
             }

--- a/lib/Transport/Entity/Schedule/Stop.php
+++ b/lib/Transport/Entity/Schedule/Stop.php
@@ -97,6 +97,16 @@ class Stop
                 $obj->delay = (strtotime($obj->prognosis->departure) - strtotime($obj->departure)) / 60;
             }
         }
+        if ($obj->delay) {
+             $obj->prognosis->realtimeProb = 100; //yes
+        }
+        if ($xml->StAttrList) {
+            foreach ($xml->StAttrList->StAttr as $attr) {
+                if ($attr["code"] == "RA") {
+                    $obj->prognosis->realtimeProb = 75; //maybe
+                }
+            }
+        }
 
         return $obj;
     }

--- a/test/Transport/Test/Entity/Schedule/ConnectionDelayTest.php
+++ b/test/Transport/Test/Entity/Schedule/ConnectionDelayTest.php
@@ -12,12 +12,13 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
         $from = new Entity\Schedule\Stop();
         $from->departure = '2012-01-16T16:10:00+0100';
         $from->departureTimestamp = 1326726600;
-        $from->delay = '8';
+        $from->delay = 8;
         $from->platform = '3';
         $prognosis = new Entity\Schedule\Prognosis();
             $prognosis->departure = '2012-01-16T16:18:00+0100';
-            $prognosis->capacity1st = '1';
-            $prognosis->capacity2nd = '1';
+            $prognosis->capacity1st = 1;
+            $prognosis->capacity2nd = 1;
+            $prognosis->realtimeProb = 75;
         $from->prognosis = $prognosis;
         $station = new Entity\Location\Station();
             $station->name = "Zürich Altstetten";
@@ -34,6 +35,9 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
         $to->arrival = '2012-01-16T16:49:00+0100';
         $to->arrivalTimestamp = 1326728940;
         $to->platform = '7';
+        $prognosis = new Entity\Schedule\Prognosis();
+            $prognosis->realtimeProb = 75;
+        $to->prognosis = $prognosis;
         $station = new Entity\Location\Station();
             $station->name = "Zug";
             $station->id = "008502204";
@@ -76,6 +80,9 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $sectionTo->station = $station;
         $sectionTo->location = $station;
+        $prognosis = new Entity\Schedule\Prognosis();
+            $prognosis->realtimeProb = 75;
+        $sectionTo->prognosis = $prognosis;
 
         $section1 = new Entity\Schedule\Section();
         $section1->walk = $sectionWalk;
@@ -93,12 +100,13 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
         $sectionFrom = new Entity\Schedule\Stop();
         $sectionFrom->departure = '2012-01-16T16:10:00+0100';
         $sectionFrom->departureTimestamp = 1326726600;
-        $sectionFrom->delay = '8';
+        $sectionFrom->delay = 8;
         $sectionFrom->platform = '3';
         $prognosis = new Entity\Schedule\Prognosis();
             $prognosis->departure = '2012-01-16T16:18:00+0100';
-            $prognosis->capacity1st = '1';
-            $prognosis->capacity2nd = '1';
+            $prognosis->capacity1st = 1;
+            $prognosis->capacity2nd = 1;
+            $prognosis->realtimeProb = 75;
         $sectionFrom->prognosis = $prognosis;
         $station = new Entity\Location\Station();
             $station->name = "Zürich Altstetten";
@@ -115,6 +123,10 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
         $sectionTo->arrival = '2012-01-16T16:49:00+0100';
         $sectionTo->arrivalTimestamp = 1326728940;
         $sectionTo->platform = '7';
+        $prognosis = new Entity\Schedule\Prognosis();
+            $prognosis->realtimeProb = 75;
+        $sectionTo->prognosis = $prognosis;
+
         $station = new Entity\Location\Station();
             $station->name = "Zug";
             $station->id = "008502204";

--- a/test/Transport/Test/Entity/Schedule/ConnectionTest.php
+++ b/test/Transport/Test/Entity/Schedule/ConnectionTest.php
@@ -24,8 +24,9 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $from->departureTimestamp = 1328033640;
         $from->platform = '21/22';
         $prognosis = new Entity\Schedule\Prognosis();
-        $prognosis->capacity1st = '1';
-        $prognosis->capacity2nd = '2';
+        $prognosis->capacity1st = 1;
+        $prognosis->capacity2nd = 2;
+        $prognosis->realtimeProb = 75;
         $from->prognosis = $prognosis;
         $station = new Entity\Location\Station();
             $station->name = "Zürich HB";
@@ -42,6 +43,9 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $to->arrival = '2012-01-31T19:42:00+0100';
         $to->arrivalTimestamp = 1328035320;
         $to->platform = '3';
+        $prognosis = new Entity\Schedule\Prognosis();
+        $prognosis->realtimeProb = 75;
+        $to->prognosis = $prognosis;
         $station = new Entity\Location\Station();
             $station->name = "Baden";
             $station->id = "008503504";


### PR DESCRIPTION
The source data has no clear indication, if the data is realtime or not. Therefore add a probability for that

0 = no
25 = maybe not
75 = maybe
100 = certainly

Not sure, if that's the right way, but it certainly would help me (or Time for Coffee) to display, if the info is real time or not, currently only possible, when there's a delay