### PR TITLE
Show departure delay also when there's a arrival prognosis

### DIFF
--- a/lib/Transport/Entity/Schedule/Prognosis.php
+++ b/lib/Transport/Entity/Schedule/Prognosis.php
@@ -32,9 +32,12 @@ class Prognosis
                 if ($xml->Dep->Platform) {
                     $obj->platform = (string) $xml->Dep->Platform->Text;
                 }
-                if ($xml->Dep->Time) {
-                    $obj->departure = Stop::calculateDateTime((string) $xml->Dep->Time, $date)->format(\DateTime::ISO8601);
-                }
+            }
+        }
+        
+        if ($xml->Dep) {
+            if ($xml->Dep->Time) {
+                $obj->departure = Stop::calculateDateTime((string) $xml->Dep->Time, $date)->format(\DateTime::ISO8601);
             }
         }
 


### PR DESCRIPTION
When it was a arrival prognosis, the departure delay wasn't shown, even it was available.