### PR TITLE
add RA parameter

### DIFF
--- a/lib/Transport/Entity/Schedule/Stop.php
+++ b/lib/Transport/Entity/Schedule/Stop.php
@@ -23,8 +23,8 @@ class Stop
 
     public $prognosis;
     
-    public $RA;
-    
+    public $realtimeAvailability;
+
     public function __construct()
     {
         $this->prognosis = new Prognosis();
@@ -103,7 +103,7 @@ class Stop
         if ($xml->StAttrList) {
             foreach ($xml->StAttrList->StAttr as $attr) {
                 if ($attr["code"] == "RA" ) {
-                    $obj->RA = (string) $attr['text'];
+                    $obj->realtimeAvailability = (string) $attr['text'];
                 }
             }
         }

--- a/lib/Transport/Entity/Schedule/Stop.php
+++ b/lib/Transport/Entity/Schedule/Stop.php
@@ -23,6 +23,8 @@ class Stop
 
     public $prognosis;
     
+    public $RA;
+    
     public function __construct()
     {
         $this->prognosis = new Prognosis();
@@ -95,6 +97,14 @@ class Stop
             }
             if ($obj->prognosis->departure && $obj->departure) {
                 $obj->delay = (strtotime($obj->prognosis->departure) - strtotime($obj->departure)) / 60;
+            }
+        }
+        
+        if ($xml->StAttrList) {
+            foreach ($xml->StAttrList->StAttr as $attr) {
+                if ($attr["code"] == "RA" ) {
+                    $obj->RA = (string) $attr['text'];
+                }
             }
         }
 

--- a/test/Transport/Test/Entity/Schedule/ConnectionDelayTest.php
+++ b/test/Transport/Test/Entity/Schedule/ConnectionDelayTest.php
@@ -12,7 +12,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
         $from = new Entity\Schedule\Stop();
         $from->departure = '2012-01-16T16:10:00+0100';
         $from->departureTimestamp = 1326726600;
-        $from->delay = '8';
+        $from->delay = 8;
         $from->platform = '3';
         $prognosis = new Entity\Schedule\Prognosis();
             $prognosis->departure = '2012-01-16T16:18:00+0100';
@@ -29,6 +29,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $from->station = $station;
         $from->location = $station;
+        $from->RA = 'RT_BHF';
 
         $to = new Entity\Schedule\Stop();
         $to->arrival = '2012-01-16T16:49:00+0100';
@@ -44,7 +45,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $to->station = $station;
         $to->location = $station;
-
+        $to->RA = 'RT_BHF';
 
         $sectionWalk = new Entity\Schedule\Walk();
         $sectionWalk->duration = '00:04:00';
@@ -76,6 +77,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $sectionTo->station = $station;
         $sectionTo->location = $station;
+        $sectionTo->RA = 'RT_BHF';
 
         $section1 = new Entity\Schedule\Section();
         $section1->walk = $sectionWalk;
@@ -110,6 +112,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $sectionFrom->station = $station;
         $sectionFrom->location = $station;
+        $sectionFrom->RA = 'RT_BHF';
 
         $sectionTo = new Entity\Schedule\Stop();
         $sectionTo->arrival = '2012-01-16T16:49:00+0100';
@@ -125,6 +128,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $sectionTo->station = $station;
         $sectionTo->location = $station;
+        $sectionTo->RA = 'RT_BHF';
 
         $passList = array();
         $passList[0] = clone $sectionFrom;

--- a/test/Transport/Test/Entity/Schedule/ConnectionDelayTest.php
+++ b/test/Transport/Test/Entity/Schedule/ConnectionDelayTest.php
@@ -29,7 +29,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $from->station = $station;
         $from->location = $station;
-        $from->RA = 'RT_BHF';
+        $from->realtimeAvailability = 'RT_BHF';
 
         $to = new Entity\Schedule\Stop();
         $to->arrival = '2012-01-16T16:49:00+0100';
@@ -45,7 +45,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $to->station = $station;
         $to->location = $station;
-        $to->RA = 'RT_BHF';
+        $to->realtimeAvailability = 'RT_BHF';
 
         $sectionWalk = new Entity\Schedule\Walk();
         $sectionWalk->duration = '00:04:00';
@@ -77,7 +77,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $sectionTo->station = $station;
         $sectionTo->location = $station;
-        $sectionTo->RA = 'RT_BHF';
+        $sectionTo->realtimeAvailability = 'RT_BHF';
 
         $section1 = new Entity\Schedule\Section();
         $section1->walk = $sectionWalk;
@@ -112,7 +112,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $sectionFrom->station = $station;
         $sectionFrom->location = $station;
-        $sectionFrom->RA = 'RT_BHF';
+        $sectionFrom->realtimeAvailability = 'RT_BHF';
 
         $sectionTo = new Entity\Schedule\Stop();
         $sectionTo->arrival = '2012-01-16T16:49:00+0100';
@@ -128,7 +128,7 @@ class ConnectionDelayTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $sectionTo->station = $station;
         $sectionTo->location = $station;
-        $sectionTo->RA = 'RT_BHF';
+        $sectionTo->realtimeAvailability = 'RT_BHF';
 
         $passList = array();
         $passList[0] = clone $sectionFrom;

--- a/test/Transport/Test/Entity/Schedule/ConnectionTest.php
+++ b/test/Transport/Test/Entity/Schedule/ConnectionTest.php
@@ -37,7 +37,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $from->station = $station;
         $from->location = $station;
-        $from->RA = 'RT_BHF';
+        $from->realtimeAvailability = 'RT_BHF';
 
         $to = new Entity\Schedule\Stop();
         $to->arrival = '2012-01-31T19:42:00+0100';
@@ -53,7 +53,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $to->station = $station;
         $to->location = $station;
-        $to->RA = 'RT_BHF';
+        $to->realtimeAvailability = 'RT_BHF';
 
         $passList = array();
         $passList[0] = clone $from;

--- a/test/Transport/Test/Entity/Schedule/ConnectionTest.php
+++ b/test/Transport/Test/Entity/Schedule/ConnectionTest.php
@@ -37,6 +37,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $from->station = $station;
         $from->location = $station;
+        $from->RA = 'RT_BHF';
 
         $to = new Entity\Schedule\Stop();
         $to->arrival = '2012-01-31T19:42:00+0100';
@@ -52,7 +53,8 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             $station->coordinate = $coordinates;
         $to->station = $station;
         $to->location = $station;
-        
+        $to->RA = 'RT_BHF';
+
         $passList = array();
         $passList[0] = clone $from;
         $passList[0]->platform = '';


### PR DESCRIPTION
The source delivers an RA property when that stop does deliver RealTime data [1], so pass that through in the API

[1] Just from experience, I don't have prove, that this is always the case...

PS. I'm open to name that parameter differently ;)
