### PR TITLE
Add Swagger specification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "twig/twig": "~1.23",
         "monolog/monolog": "~1.17",
         "symfony/serializer": "~2.3|3.0.*",
-        "ekino/newrelic-bundle": "~1.3"
+        "ekino/newrelic-bundle": "~1.3",
+        "zircote/swagger-php": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,131 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4d1c2c18f1cd7400164fa3fdc85c88b5",
-    "content-hash": "d681940500f68e610c7a9cce6ae3ab92",
+    "hash": "66624a2337301a63ec56d1141c3d18ea",
+    "content-hash": "98043a87c2224a35b155d60e38041627",
     "packages": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Annotations\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2015-08-31 12:32:49"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09 13:34:57"
+        },
         {
             "name": "ekino/newrelic-bundle",
             "version": "1.3.2",
@@ -559,6 +681,55 @@
             "time": "2016-05-03 18:59:18"
         },
         {
+            "name": "symfony/finder",
+            "version": "v2.8.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "ca24cf2cd4e3826f571e0067e535758e73807aa1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ca24cf2cd4e3826f571e0067e535758e73807aa1",
+                "reference": "ca24cf2cd4e3826f571e0067e535758e73807aa1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-03-10 10:53:53"
+        },
+        {
             "name": "symfony/http-foundation",
             "version": "v2.8.6",
             "source": {
@@ -1067,6 +1238,67 @@
                 "templating"
             ],
             "time": "2016-01-25 21:22:18"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "5d8afafcf3935133f85891b9a0326b7ed0784e59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/5d8afafcf3935133f85891b9a0326b7ed0784e59",
+                "reference": "5d8afafcf3935133f85891b9a0326b7ed0784e59",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "*",
+                "php": ">=5.4.0",
+                "symfony/finder": "*"
+            },
+            "require-dev": {
+                "squizlabs/php_codesniffer": "2.*",
+                "zendframework/zend-form": "*"
+            },
+            "bin": [
+                "bin/swagger"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Swagger\\": "src"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com",
+                    "homepage": "http://www.zircote.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "http://bfanger.nl"
+                }
+            ],
+            "description": "Swagger-PHP - Generate interactive documentation for your RESTful API using phpdoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php/",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "time": "2016-04-21 19:26:57"
         }
     ],
     "packages-dev": [
@@ -2142,7 +2374,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zircote/swagger-php": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/lib/Transport/Entity/Coordinate.php
+++ b/lib/Transport/Entity/Coordinate.php
@@ -2,20 +2,29 @@
 
 namespace Transport\Entity;
 
+/**
+ * @SWG\Definition()
+ */
 class Coordinate
 {
     /**
+     * The type of the given coordinate
      * @var string
+     * @SWG\Property()
      */
     public $type;
 
     /**
+     * Latitude
      * @var int
+     * @SWG\Property()
      */
     public $x;
 
     /**
+     * Longitude
      * @var int
+     * @SWG\Property()
      */
     public $y;
 

--- a/lib/Transport/Entity/Location/Address.php
+++ b/lib/Transport/Entity/Location/Address.php
@@ -8,6 +8,8 @@ use Transport\Entity\Coordinate;
  * Represents a Address we received as response
  *
  * <Address name="3011 Bern, Bollwerk 19" type="WGS84" x="7440803" y="46949607"/>
+ *
+ * @SWG\Definition()
  */
 class Address extends Location
 {

--- a/lib/Transport/Entity/Location/Location.php
+++ b/lib/Transport/Entity/Location/Location.php
@@ -4,27 +4,36 @@ namespace Transport\Entity\Location;
 
 use Transport\Entity\Coordinate;
 
+/**
+ * @SWG\Definition()
+ */
 class Location
 {
     /**
      * The name of this location
      * @var string
+     * @SWG\Property()
      */
     public $name;
 
     /**
      * The score with regard to the search request, the higher the better
      * @var int
+     * @SWG\Property()
      */
     public $score;
 
     /**
+     * The location coordinates
      * @var Coordinate
+     * @SWG\Property()
      */
     public $coordinate;
 
     /**
+     * If search has been with coordinates, distance to original point in meters
      * @var int
+     * @SWG\Property()
      */
     public $distance;
 

--- a/lib/Transport/Entity/Location/Poi.php
+++ b/lib/Transport/Entity/Location/Poi.php
@@ -6,6 +6,8 @@ namespace Transport\Entity\Location;
  * Represents a Poi we received as response
  *
  * <Poi name="Ittigen, Bahnhof" score="100" type="WGS84" x="7478189" y="46976494" />
+ *
+ * @SWG\Definition()
  */
 class Poi extends Location
 {

--- a/lib/Transport/Entity/Location/Station.php
+++ b/lib/Transport/Entity/Location/Station.php
@@ -6,11 +6,16 @@ namespace Transport\Entity\Location;
  * Represents a station we received as response
  *
  * <Station name="Bern Felsenau" score="81" externalId="008508051#95" externalStationNr="008508051" type="WGS84" x="7444245" y="46968493"/>
+ *
+ * @SWG\Definition()
  */
 class Station extends Location
 {
     /**
+     * The ID of the station
+     *
      * @var string
+     * @SWG\Property()
      */
     public $id;
 

--- a/lib/Transport/Entity/Schedule/Connection.php
+++ b/lib/Transport/Entity/Schedule/Connection.php
@@ -5,52 +5,71 @@ namespace Transport\Entity\Schedule;
 use Transport\Entity;
 
 /**
- * Connection
+ * A connection represents a possible journey between two locations.
+ *
+ * @SWG\Definition()
  */
 class Connection
 {
     /**
-     * @var Transport\Entity\Schedule\Stop
+     * The departure checkpoint of the connection
+     * @var \Transport\Entity\Schedule\Stop
+     * @SWG\Property()
      */
     public $from;
 
     /**
-     * @var Transport\Entity\Schedule\Stop
+     * The arrival checkpoint of the connection
+     * @var \Transport\Entity\Schedule\Stop
+     * @SWG\Property()
      */
     public $to;
     
     /**
+     * Duration of the journey (e.g. 00d00:43:00)
      * @var String
+     * @SWG\Property()
      */
     public $duration;
     
     /**
+     * Service information about how regular the connection operates
      * @var int
+     * @SWG\Property()
      */
     public $transfers;
 
     /**
-     * @var Transport\EntitySchedule\Service
+     * List of transport products (e.g. IR, S9)
+     * @var \Transport\Entity\Schedule\Service
+     * @SWG\Property()
      */
     public $service;
 
     /**
-     * @var array
+     * @var string[]
+     * @SWG\Property()
      */
     public $products = array();
     
     /**
+     * The maximum estimated occupation load of 1st class coaches (e.g. 1)
      * @var int
+     * @SWG\Property()
      */
     public $capacity1st = null;
     
     /**
+     * The maximum estimated occupation load of 2nd class coaches (e.g. 2)
      * @var int
+     * @SWG\Property()
      */
     public $capacity2nd = null;
 
     /**
-     * @var array of Transport\Entity\Schedule\Stop 's
+     * A list of sections
+     * @var \Transport\Entity\Schedule\Section[]
+     * @SWG\Property()
      */
     public $sections;
 

--- a/lib/Transport/Entity/Schedule/Journey.php
+++ b/lib/Transport/Entity/Schedule/Journey.php
@@ -2,63 +2,79 @@
 
 namespace Transport\Entity\Schedule;
 
+/**
+ * The actual transportation of a section, e.g. a bus or a train between two stations.
+ *
+ * @SWG\Definition()
+ */
 class Journey
 {
     /**
+     * The name of the connection (e.g. ICN 518)
      * @var string
+     * @SWG\Property()
      */
     public $name;
 
     /**
+     * The type of connection this is (e.g. ICN)
      * @var string
+     * @SWG\Property()
      */
     public $category;
 
     /**
      * @var string
+     * @SWG\Property()
      */
     public $subcategory;
 
     /**
-     * Indicates the type of the public transport vehicle. Possible values:
-     * 
-     * + 0, 1, 2, 3, 5, 8: train
-     * + 4: ship
-     * + 6: bus
-     * + 7: cable car (aerial, big)
-     * + 9: tram
-     *
+     * An internal category code, indicates the type of the public transport vehicle. Possible values are 0, 1, 2, 3, 5, 8: train; 4: ship; 6: bus; 7: cable car (aerial, big); 9: tram
      * @var int
+     * @SWG\Property()
      */
     public $categoryCode;
 
     /**
+     * The number of the connection's line (e.g. 518)
      * @var string
+     * @SWG\Property()
      */
     public $number;
 
     /**
+     * The operator of the connection's line (e.g. BBA)
      * @var string
+     * @SWG\Property()
      */
     public $operator;
 
     /**
+     * The final destination of this line (e.g. Aarau Rohr, Unterdorf)
      * @var string
+     * @SWG\Property()
      */
     public $to;
 
     /**
-     * @var array
+     * Checkpoints the train passed on the journey
+     * @var \Transport\Entity\Schedule\Stop[]
+     * @SWG\Property()
      */
     public $passList = array();
 
     /**
+     * The maximum estimated occupation load of 1st class coaches (e.g. 1)
      * @var int
+     * @SWG\Property()
      */
     public $capacity1st = null;
 
     /**
+     * The maximum estimated occupation load of 2nd class coaches (e.g. 2)
      * @var int
+     * @SWG\Property()
      */
     public $capacity2nd = null;
 

--- a/lib/Transport/Entity/Schedule/Prognosis.php
+++ b/lib/Transport/Entity/Schedule/Prognosis.php
@@ -2,12 +2,46 @@
 
 namespace Transport\Entity\Schedule;
 
+/**
+ * A prognosis contains "realtime" informations on the status of a connection checkpoint.
+ *
+ * @SWG\Definition()
+ */
 class Prognosis
 {
+    /**
+     * The estimated arrival/departure platform (e.g. 8)
+     * @var string
+     * @SWG\Property()
+     */
     public $platform;
+
+    /**
+     * The departure time prognosis to the checkpoint, date format: [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) (e.g. 2012-03-31T08:58:00+02:00)
+     * @var string
+     * @SWG\Property()
+     */
     public $arrival;
+
+    /**
+     * The arrival time prognosis to the checkpoint, date format: [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) (e.g. 2012-03-31T09:35:00+02:00)
+     * @var string
+     * @SWG\Property()
+     */
     public $departure;
+
+    /**
+     * The estimated occupation load of 1st class coaches (e.g. 1)
+     * @var int
+     * @SWG\Property()
+     */
     public $capacity1st;
+
+    /**
+     * The estimated occupation load of 2nd class coaches (e.g. 2)
+     * @var int
+     * @SWG\Property()
+     */
     public $capacity2nd;
 
     public static function createFromXml(\SimpleXMLElement $xml, \DateTime $date, $isArrival, Prognosis $obj = null)

--- a/lib/Transport/Entity/Schedule/Section.php
+++ b/lib/Transport/Entity/Schedule/Section.php
@@ -4,25 +4,38 @@ namespace Transport\Entity\Schedule;
 
 use Transport\Entity;
 
+/**
+ * A connection consists of one or multiple sections.
+ *
+ * @SWG\Definition()
+ */
 class Section
 {
     /**
+     * A journey, the transportation used by this section, can be null
      * @var Entity\Schedule\Journey
+     * @SWG\Property()
      */
     public $journey;
 
     /**
+     * Information about walking distance, if available, can be null
      * @var Entity\Schedule\Walk
+     * @SWG\Property()
      */
     public $walk;
 
     /**
+     * The departure checkpoint of the connection
      * @var Entity\Schedule\Stop
+     * @SWG\Property()
      */
     public $departure;
 
     /**
+     * The arrival checkpoint of the connection
      * @var Entity\Schedule\Stop
+     * @SWG\Property()
      */
     public $arrival;
     

--- a/lib/Transport/Entity/Schedule/Service.php
+++ b/lib/Transport/Entity/Schedule/Service.php
@@ -2,15 +2,24 @@
 
 namespace Transport\Entity\Schedule;
 
+/**
+ * Operation information for a connection.
+ *
+ * @SWG\Definition()
+ */
 class Service
 {
     /**
+     * Information about how regular a connection operates (e.g. daily).
      * @var string
+     * @SWG\Property()
      */
     public $regular;
 
     /**
+     * Additional information about irregular operation dates (e.g. not 23., 24. Jun 2012).
      * @var string
+     * @SWG\Property()
      */
     public $irregular;
 }

--- a/lib/Transport/Entity/Schedule/StationBoardJourney.php
+++ b/lib/Transport/Entity/Schedule/StationBoardJourney.php
@@ -4,11 +4,14 @@ namespace Transport\Entity\Schedule;
 
 /**
  * Request for a station board journey
+ *
+ * @SWG\Definition()
  */
 class StationBoardJourney extends Journey
 {
     /**
-     * @var Transport\Entity\Schedule\Stop
+     * @var \Transport\Entity\Schedule\Stop
+     * @SWG\Property()
      */
     public $stop;
 

--- a/lib/Transport/Entity/Schedule/Stop.php
+++ b/lib/Transport/Entity/Schedule/Stop.php
@@ -6,25 +6,74 @@ use Transport\Entity;
 
 /**
  * Basic Stop
+ *
+ * @SWG\Definition()
  */
 class Stop
 {
+    /**
+     * A location object showing this line's stop at the requested station
+     * @var \Transport\Entity\Location\Station
+     * @SWG\Property()
+     */
     public $station;
 
+    /**
+     * The arrival time to the checkpoint (e.g. 14:58:00)
+     * @var string
+     * @SWG\Property()
+     */
     public $arrival;
+
+    /**
+     * @var int
+     * @SWG\Property()
+     */
     public $arrivalTimestamp;
 
+    /**
+     * The departure time from the checkpoint, can be null
+     * @var string
+     * @SWG\Property()
+     */
     public $departure;
+
+    /**
+     * @var int
+     * @SWG\Property()
+     */
     public $departureTimestamp;
 
+    /**
+     * @var int
+     * @SWG\Property()
+     */
     public $delay;
 
+    /**
+     * The arrival/departure platform (e.g. 8)
+     * @var string
+     * @SWG\Property()
+     */
     public $platform;
 
+    /**
+     * The checkpoint prognosis
+     * @var \Transport\Entity\Schedule\Prognosis
+     * @SWG\Property()
+     */
     public $prognosis;
 
+    /**
+     * @var string
+     * @SWG\Property()
+     */
     public $realtimeAvailability;
 
+    /**
+     * @var \Transport\Entity\Location\Location
+     * @SWG\Property()
+     */
     public $location;
 
     public function __construct()

--- a/lib/Transport/Entity/Schedule/Walk.php
+++ b/lib/Transport/Entity/Schedule/Walk.php
@@ -2,10 +2,14 @@
 
 namespace Transport\Entity\Schedule;
 
+/**
+ * @SWG\Definition()
+ */
 class Walk
 {
     /**
      * @var int
+     * @SWG\Property()
      */
     public $duration;
 

--- a/test/Transport/Test/SwaggerTest.php
+++ b/test/Transport/Test/SwaggerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Transport\Test;
+
+use Buzz\Message\Response;
+
+class SwaggerTest extends IntegrationTest
+{
+    public function testSwaggerJson()
+    {
+        $client = $this->createClient();
+        $crawler = $client->request('GET', '/swagger.json');
+
+        $this->assertEquals($this->getFixture('swagger.json'), $client->getResponse()->getContent());
+        $this->assertTrue($client->getResponse()->isOk());
+    }
+}

--- a/test/fixtures/swagger.json
+++ b/test/fixtures/swagger.json
@@ -1,0 +1,611 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Transport API",
+        "version": "1.0"
+    },
+    "host": "transport.opendata.ch",
+    "basePath": "/v1",
+    "schemes": [
+        "http",
+        "https"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/locations": {
+            "get": {
+                "tags": [
+                    "locations"
+                ],
+                "summary": "Search locations",
+                "description": "Returns the matching locations for the given parameters. Either query or ( x and y ) are required.\n\nThe locations in the response are scored to determine which is the most exact location.\n\nThis method can return a refine response, what means that the request has to be redone.",
+                "parameters": [
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "description": "Specifies the location name to search for (e.g. Basel)",
+                        "type": "string"
+                    },
+                    {
+                        "name": "x",
+                        "in": "query",
+                        "description": "Latitude (e.g. 47.476001)",
+                        "type": "number"
+                    },
+                    {
+                        "name": "y",
+                        "in": "query",
+                        "description": "Longitude (e.g. 8.306130)",
+                        "type": "number"
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Only with `query` parameter. Specifies the location type, possible types are:<ul><li>`all` (default): Looks up for all types of locations</li><li>`station`: Looks up for stations (train station, bus station)</li><li>`poi`: Looks up for points of interest (Clock tower, China garden)</li><li>`address`: Looks up for an address (Zurich Bahnhofstrasse 33)</li></ul>",
+                        "type": "string"
+                    },
+                    {
+                        "name": "transportations[]",
+                        "in": "query",
+                        "description": "Only with `x` and `y` parameter. Transportation means; one or more of `ice_tgv_rj`, `ec_ic`, `ir`, `re_d`, `ship`, `s_sn_r`, `bus`, `cableway`, `arz_ext`, `tramway_underground` (e.g. transportations[]=ec_ic&transportations[]=bus)",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of locations",
+                        "schema": {
+                            "properties": {
+                                "stations": {
+                                    "description": "Search locations\n\nReturns the matching locations for the given parameters. Either query or ( x and y ) are required.\n\nThe locations in the response are scored to determine which is the most exact location.\n\nThis method can return a refine response, what means that the request has to be redone.",
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Location"
+                                    }
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
+        "/connections": {
+            "get": {
+                "tags": [
+                    "connections"
+                ],
+                "summary": "Search connections",
+                "description": "Returns the next connections from a location to another.",
+                "parameters": [
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "description": "Specifies the departure location of the connection (e.g. Lausanne)",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "description": "Specifies the arrival location of the connection (e.g. Gen\u00e8ve)",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "via[]",
+                        "in": "query",
+                        "description": "Specifies up to five via locations. When specifying several vias, array notation (via[]=Bern&via[]=Fribourg) is required",
+                        "type": "string"
+                    },
+                    {
+                        "name": "date",
+                        "in": "query",
+                        "description": "Date of the connection, in the format YYYY-MM-DD (e.g. 2012-03-25)",
+                        "type": "string"
+                    },
+                    {
+                        "name": "time",
+                        "in": "query",
+                        "description": "Time of the connection, in the format hh:mm (e.g. 17:30)",
+                        "type": "string"
+                    },
+                    {
+                        "name": "isArrivalTime",
+                        "in": "query",
+                        "description": "defaults to `0`, if set to `1` the passed `date` and `time` is the arrival time",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "transportations[]",
+                        "in": "query",
+                        "description": "Transportation means; one or more of `ice_tgv_rj`, `ec_ic`, `ir`, `re_d`, `ship`, `s_sn_r`, `bus`, `cableway`, `arz_ext`, `tramway_underground` (e.g. transportations[]=ec_ic&transportations[]=bus)",
+                        "type": "string"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "1 - 6. Specifies the number of connections to return. If several connections depart at the same time they are counted as 1.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "0 - 10. Allows pagination of connections. Zero-based, so first page is 0, second is 1, third is 2 and so on.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "direct",
+                        "in": "query",
+                        "description": "defaults to `0`, if set to `1` only direct connections are allowed",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "sleeper",
+                        "in": "query",
+                        "description": "defaults to `0`, if set to `1` only night trains containing beds are allowed, implies `direct=1`",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "couchette",
+                        "in": "query",
+                        "description": "defaults to `0`, if set to `1` only night trains containing couchettes are allowed, implies `direct=1`",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "bike",
+                        "in": "query",
+                        "description": "defaults to `0`, if set to `1` only trains allowing the transport of bicycles are allowed",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "accessibility",
+                        "in": "query",
+                        "description": "Possible values are `independent_boarding`, `assisted_boarding`, and `advanced_notice`",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "A list of connections",
+                        "schema": {
+                            "properties": {
+                                "connections": {
+                                    "description": "Search connections\n\nReturns the next connections from a location to another.",
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Connection"
+                                    }
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
+        "/stationboard": {
+            "get": {
+                "tags": [
+                    "stationboard"
+                ],
+                "summary": "Get station board",
+                "description": "Returns the next connections leaving from a specific location.",
+                "parameters": [
+                    {
+                        "name": "station",
+                        "in": "query",
+                        "description": "Specifies the location of which a stationboard should be returned (e.g. Aarau)",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The id of the station whose stationboard should be returned. Alternative to the station parameter; one of these two is required. If both an id and a station are specified the id has precedence. e.g. 8503059 (for Zurich Stadelhofen)",
+                        "type": "string"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Number of departing connections to return. This is not a hard limit - if multiple connections leave at the same time it'll return any connections that leave at the same time as the last connection within the limit. For example: `limit=4` will return connections leaving at: 19:30, 19:32, 19:32, 19:35, 19:35. Because one of the connections leaving at 19:35 is within the limit, all connections leaving at 19:35 are shown.",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "transportations[]",
+                        "in": "query",
+                        "description": "Transportation means; one or more of `ice_tgv_rj`, `ec_ic`, `ir`, `re_d`, `ship`, `s_sn_r`, `bus`, `cableway`, `arz_ext`, `tramway_underground` (e.g. transportations[]=ec_ic&transportations[]=bus)",
+                        "type": "string"
+                    },
+                    {
+                        "name": "datetime",
+                        "in": "query",
+                        "description": "Date and time of departing connections, in the format `YYYY-MM-DD hh:mm` (e.g. 2012-03-25 17:30)",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Stationboard",
+                        "schema": {
+                            "properties": {
+                                "station": {
+                                    "description": "The first matched location based on the query. The stationboard will be displayed if this is a station.",
+                                    "$ref": "#/definitions/Station"
+                                },
+                                "stationboard": {
+                                    "description": "A list of journeys with the stop of the line leaving from that station.",
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/Journey"
+                                    }
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Coordinate": {
+            "properties": {
+                "type": {
+                    "description": "The type of the given coordinate",
+                    "type": "string"
+                },
+                "x": {
+                    "description": "Latitude",
+                    "type": "integer"
+                },
+                "y": {
+                    "description": "Longitude",
+                    "type": "integer"
+                }
+            }
+        },
+        "Address": {
+            "properties": {
+                "name": {
+                    "description": "The name of this location",
+                    "type": "string"
+                },
+                "score": {
+                    "description": "The score with regard to the search request, the higher the better",
+                    "type": "integer"
+                },
+                "coordinate": {
+                    "description": "The location coordinates",
+                    "$ref": "#/definitions/Coordinate"
+                },
+                "distance": {
+                    "description": "If search has been with coordinates, distance to original point in meters",
+                    "type": "integer"
+                }
+            }
+        },
+        "Location": {
+            "properties": {
+                "name": {
+                    "description": "The name of this location",
+                    "type": "string"
+                },
+                "score": {
+                    "description": "The score with regard to the search request, the higher the better",
+                    "type": "integer"
+                },
+                "coordinate": {
+                    "description": "The location coordinates",
+                    "$ref": "#/definitions/Coordinate"
+                },
+                "distance": {
+                    "description": "If search has been with coordinates, distance to original point in meters",
+                    "type": "integer"
+                }
+            }
+        },
+        "Poi": {
+            "properties": {
+                "name": {
+                    "description": "The name of this location",
+                    "type": "string"
+                },
+                "score": {
+                    "description": "The score with regard to the search request, the higher the better",
+                    "type": "integer"
+                },
+                "coordinate": {
+                    "description": "The location coordinates",
+                    "$ref": "#/definitions/Coordinate"
+                },
+                "distance": {
+                    "description": "If search has been with coordinates, distance to original point in meters",
+                    "type": "integer"
+                }
+            }
+        },
+        "Station": {
+            "properties": {
+                "id": {
+                    "description": "The ID of the station",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of this location",
+                    "type": "string"
+                },
+                "score": {
+                    "description": "The score with regard to the search request, the higher the better",
+                    "type": "integer"
+                },
+                "coordinate": {
+                    "description": "The location coordinates",
+                    "$ref": "#/definitions/Coordinate"
+                },
+                "distance": {
+                    "description": "If search has been with coordinates, distance to original point in meters",
+                    "type": "integer"
+                }
+            }
+        },
+        "Connection": {
+            "properties": {
+                "from": {
+                    "description": "The departure checkpoint of the connection",
+                    "$ref": "#/definitions/Stop"
+                },
+                "to": {
+                    "description": "The arrival checkpoint of the connection",
+                    "$ref": "#/definitions/Stop"
+                },
+                "duration": {
+                    "description": "Duration of the journey (e.g. 00d00:43:00)",
+                    "type": "string"
+                },
+                "transfers": {
+                    "description": "Service information about how regular the connection operates",
+                    "type": "integer"
+                },
+                "service": {
+                    "description": "List of transport products (e.g. IR, S9)",
+                    "$ref": "#/definitions/Service"
+                },
+                "products": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "capacity1st": {
+                    "description": "The maximum estimated occupation load of 1st class coaches (e.g. 1)",
+                    "type": "integer"
+                },
+                "capacity2nd": {
+                    "description": "The maximum estimated occupation load of 2nd class coaches (e.g. 2)",
+                    "type": "integer"
+                },
+                "sections": {
+                    "description": "A list of sections",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Section"
+                    }
+                }
+            }
+        },
+        "Journey": {
+            "properties": {
+                "name": {
+                    "description": "The name of the connection (e.g. ICN 518)",
+                    "type": "string"
+                },
+                "category": {
+                    "description": "The type of connection this is (e.g. ICN)",
+                    "type": "string"
+                },
+                "subcategory": {
+                    "type": "string"
+                },
+                "categoryCode": {
+                    "description": "An internal category code, indicates the type of the public transport vehicle. Possible values are 0, 1, 2, 3, 5, 8: train; 4: ship; 6: bus; 7: cable car (aerial, big); 9: tram",
+                    "type": "integer"
+                },
+                "number": {
+                    "description": "The number of the connection's line (e.g. 518)",
+                    "type": "string"
+                },
+                "operator": {
+                    "description": "The operator of the connection's line (e.g. BBA)",
+                    "type": "string"
+                },
+                "to": {
+                    "description": "The final destination of this line (e.g. Aarau Rohr, Unterdorf)",
+                    "type": "string"
+                },
+                "passList": {
+                    "description": "Checkpoints the train passed on the journey",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Stop"
+                    }
+                },
+                "capacity1st": {
+                    "description": "The maximum estimated occupation load of 1st class coaches (e.g. 1)",
+                    "type": "integer"
+                },
+                "capacity2nd": {
+                    "description": "The maximum estimated occupation load of 2nd class coaches (e.g. 2)",
+                    "type": "integer"
+                }
+            }
+        },
+        "Prognosis": {
+            "properties": {
+                "platform": {
+                    "description": "The estimated arrival/departure platform (e.g. 8)",
+                    "type": "string"
+                },
+                "arrival": {
+                    "description": "The departure time prognosis to the checkpoint, date format: [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) (e.g. 2012-03-31T08:58:00+02:00)",
+                    "type": "string"
+                },
+                "departure": {
+                    "description": "The arrival time prognosis to the checkpoint, date format: [ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) (e.g. 2012-03-31T09:35:00+02:00)",
+                    "type": "string"
+                },
+                "capacity1st": {
+                    "description": "The estimated occupation load of 1st class coaches (e.g. 1)",
+                    "type": "integer"
+                },
+                "capacity2nd": {
+                    "description": "The estimated occupation load of 2nd class coaches (e.g. 2)",
+                    "type": "integer"
+                }
+            }
+        },
+        "Section": {
+            "properties": {
+                "journey": {
+                    "description": "A journey, the transportation used by this section, can be null",
+                    "$ref": "#/definitions/Journey"
+                },
+                "walk": {
+                    "description": "Information about walking distance, if available, can be null",
+                    "$ref": "#/definitions/Walk"
+                },
+                "departure": {
+                    "description": "The departure checkpoint of the connection",
+                    "$ref": "#/definitions/Stop"
+                },
+                "arrival": {
+                    "description": "The arrival checkpoint of the connection",
+                    "$ref": "#/definitions/Stop"
+                }
+            }
+        },
+        "Service": {
+            "properties": {
+                "regular": {
+                    "description": "Information about how regular a connection operates (e.g. daily).",
+                    "type": "string"
+                },
+                "irregular": {
+                    "description": "Additional information about irregular operation dates (e.g. not 23., 24. Jun 2012).",
+                    "type": "string"
+                }
+            }
+        },
+        "StationBoardJourney": {
+            "properties": {
+                "stop": {
+                    "$ref": "#/definitions/Stop"
+                },
+                "name": {
+                    "description": "The name of the connection (e.g. ICN 518)",
+                    "type": "string"
+                },
+                "category": {
+                    "description": "The type of connection this is (e.g. ICN)",
+                    "type": "string"
+                },
+                "subcategory": {
+                    "type": "string"
+                },
+                "categoryCode": {
+                    "description": "An internal category code, indicates the type of the public transport vehicle. Possible values are 0, 1, 2, 3, 5, 8: train; 4: ship; 6: bus; 7: cable car (aerial, big); 9: tram",
+                    "type": "integer"
+                },
+                "number": {
+                    "description": "The number of the connection's line (e.g. 518)",
+                    "type": "string"
+                },
+                "operator": {
+                    "description": "The operator of the connection's line (e.g. BBA)",
+                    "type": "string"
+                },
+                "to": {
+                    "description": "The final destination of this line (e.g. Aarau Rohr, Unterdorf)",
+                    "type": "string"
+                },
+                "passList": {
+                    "description": "Checkpoints the train passed on the journey",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Stop"
+                    }
+                },
+                "capacity1st": {
+                    "description": "The maximum estimated occupation load of 1st class coaches (e.g. 1)",
+                    "type": "integer"
+                },
+                "capacity2nd": {
+                    "description": "The maximum estimated occupation load of 2nd class coaches (e.g. 2)",
+                    "type": "integer"
+                }
+            }
+        },
+        "Stop": {
+            "properties": {
+                "station": {
+                    "description": "A location object showing this line's stop at the requested station",
+                    "$ref": "#/definitions/Station"
+                },
+                "arrival": {
+                    "description": "The arrival time to the checkpoint (e.g. 14:58:00)",
+                    "type": "string"
+                },
+                "arrivalTimestamp": {
+                    "type": "integer"
+                },
+                "departure": {
+                    "description": "The departure time from the checkpoint, can be null",
+                    "type": "string"
+                },
+                "departureTimestamp": {
+                    "type": "integer"
+                },
+                "delay": {
+                    "type": "integer"
+                },
+                "platform": {
+                    "description": "The arrival/departure platform (e.g. 8)",
+                    "type": "string"
+                },
+                "prognosis": {
+                    "description": "The checkpoint prognosis",
+                    "$ref": "#/definitions/Prognosis"
+                },
+                "realtimeAvailability": {
+                    "type": "string"
+                },
+                "location": {
+                    "$ref": "#/definitions/Location"
+                }
+            }
+        },
+        "Walk": {
+            "properties": {
+                "duration": {
+                    "type": "integer"
+                }
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "locations",
+            "description": "Search for stations and locations"
+        },
+        {
+            "name": "connections",
+            "description": "Search for connections"
+        },
+        {
+            "name": "stationboard",
+            "description": "Get station board"
+        }
+    ]
+}

--- a/test/update-swagger.php
+++ b/test/update-swagger.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once 'bootstrap.php';
+
+$app = new Transport\Application();
+$client = new Symfony\Component\HttpKernel\Client($app);
+
+$client->request('GET', '/swagger.json');
+
+file_put_contents( __DIR__ . '/fixtures/swagger.json', $client->getResponse()->getContent());


### PR DESCRIPTION
> [Swagger](http://swagger.io/) is a simple yet powerful representation of your RESTful API.

[zircote/swagger-php](https://github.com/zircote/swagger-php) is used to generate the swagger.json from annotations. dev-master is used because the unreleased version has a great feature which parses PHPDocs too.

Most descriptions are derived from the current [documentation](http://transport.opendata.ch/docs.html). That documentation could actually now automatically be generated from the swagger.json.

Fixes https://github.com/OpendataCH/Transport/issues/121.