### PR TITLE
Only set Cache-Control header if HTTP cache is enabled

### DIFF
--- a/lib/Transport/Application.php
+++ b/lib/Transport/Application.php
@@ -123,9 +123,11 @@ class Application extends \Silex\Application
         $app['api'] = new \Transport\API(new \Buzz\Browser($client));
 
         // allow cross-domain requests, enable cache
-        $app->after(function (Request $request, Response $response) {
+        $app->after(function (Request $request, Response $response) use ($app) {
             $response->headers->set('Access-Control-Allow-Origin', '*');
-            $response->headers->set('Cache-Control', 's-maxage=30, public');
+            if ($app['http_cache']) {
+                $response->headers->set('Cache-Control', 's-maxage=30, public');
+            }
         });
 
         // Serializer


### PR DESCRIPTION
I propose we remove the default cache setting and only set a max-age if the HTTP cache has been enabled in the settings.

Change in HTTP response headers:

```diff
- Cache-Control: public, s-maxage=30
+ Cache-Control: no-cache
```

For most applications it's preferable to get the most recent response from SBB to detect delays or track changes. Having the rate limiting prevents too many requests. Caching by an intermediary proxy also makes the rate limiting behaving unpredictable.

Unless concerns are raised I will merge this change on 12 June 2016.