### PR TITLE
Use normal attribute variant for journey operator

### DIFF
--- a/lib/Transport/Entity/Schedule/Journey.php
+++ b/lib/Transport/Entity/Schedule/Journey.php
@@ -111,7 +111,11 @@ class Journey
                         $obj->number = (string) $journeyAttribute->Attribute->AttributeVariant->Text;
                         break;
                     case 'OPERATOR':
-                        $obj->operator = (string) $journeyAttribute->Attribute->AttributeVariant->Text;
+                        foreach ($journeyAttribute->Attribute->AttributeVariant as $journeyAttributeVariant) {
+                            if ($journeyAttributeVariant['type'] == 'NORMAL') {
+                                $obj->operator = (string) $journeyAttributeVariant->Text;
+                            }
+                        }
                         break;
                     case 'DIRECTION':
                         $obj->to = (string) $journeyAttribute->Attribute->AttributeVariant->Text;


### PR DESCRIPTION
As reported in #140 the `operator` value sometimes varies because the attribute can have different variants, e.g.

```xml
  <JourneyAttribute from="0" to="10">
    <Attribute type="OPERATOR">
      <AttributeVariant type="SHORT">
        <Text>THU</Text>
      </AttributeVariant>
      <AttributeVariant type="NORMAL">
        <Text>THURBO</Text>
      </AttributeVariant>
      <AttributeVariant type="LONG">
        <Text>THURBO</Text>
      </AttributeVariant>
    </Attribute>
  </JourneyAttribute>
```

This change makes sure the `NORMAL` operator value is used.