### PR TITLE
Added parameter to stationboard to get arrivals

### DIFF
--- a/lib/Transport/Application.php
+++ b/lib/Transport/Application.php
@@ -543,7 +543,7 @@ class Application extends \Silex\Application
                 }
                 
                 if($boardType) {	
-				    $query->boardType = $boardType;
+                    $query->boardType = $boardType;
                 }
                 
                 $query->maxJourneys = $limit;

--- a/lib/Transport/Application.php
+++ b/lib/Transport/Application.php
@@ -524,6 +524,11 @@ class Application extends \Silex\Application
             $transportations = $request->get('transportations');
 
             $station = $request->get('station') ?: $request->get('id');
+            
+            $boardType = $request->get('type');
+            if($boardType != 'ARR' AND $boardType != 'DEP' AND isset($boardType)) {
+                $boardType = 'DEP';
+            }
 
             $query = new LocationQuery($station, 'station');
             $stations = $app['api']->findLocations($query);
@@ -536,6 +541,11 @@ class Application extends \Silex\Application
                 if ($transportations) {
                     $query->transportations = (array) $transportations;
                 }
+                
+                if($boardType) {	
+				    $query->boardType = $boardType;
+                }
+                
                 $query->maxJourneys = $limit;
                 $stationboard = $app['api']->getStationBoard($query);
             }


### PR DESCRIPTION
The board type for the stationboard is hardcoded in lib/Transport/Entity/Schedule/StationBoardQuery.php to provide the departures. To be able to retrieve arrivals, these changes add another parameter for the staionboard call: "type", accepting "DEP" and "ARR". When not provided, DEP is default as before. when type is set to "ARR" the arrivals at the station are returned.