### PR TITLE
Set rate limiting to 3 requests per second per IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2016-10-28
+
+- Rate limiting set to 3 requests per second per IP address
+
 ## 2016-09-29
 
 - #140 Improve journey number by using LINE attribute

--- a/config.php.docker
+++ b/config.php.docker
@@ -6,6 +6,6 @@ $app['buzz.client'] = new Buzz\Client\Curl();
 $app['monolog.level'] = Monolog\Logger::ERROR;
 $app['redis.config'] = getenv('REDIS_HOST') ? ['host' => getenv('REDIS_HOST'), 'port' => getenv('REDIS_PORT'), 'password' => getenv('REDIS_PASSWORD')] : [];
 $app['stats.config'] = getenv('STATS_ENABLED') ? ['enabled' => true] : ['enabled' => false];
-$app['rate_limiting.config'] = getenv('RATE_LIMITING_ENABLED') ? ['enabled' => true, 'limit' => 300] : ['enabled' => false, 'limit' => 300];
+$app['rate_limiting.config'] = getenv('RATE_LIMITING_ENABLED') ? ['enabled' => true, 'limit' => 3] : ['enabled' => false, 'limit' => 3];
 $app['proxy'] = false;
 $app['proxy_server.address'] = null;

--- a/config.php.sample
+++ b/config.php.sample
@@ -19,7 +19,7 @@ $app['redis.config'] = false; // ['host' => 'localhost', 'port' => 6379];
 $app['stats.config'] = ['enabled' => false];
 
 // Rate limiting
-$app['rate_limiting.config'] = ['enabled' => false, 'limit' => 150];
+$app['rate_limiting.config'] = ['enabled' => false, 'limit' => 3];
 
 // Trusted proxies, needed for rate limiting behing a reverse proxy, e.g. $app['proxy'] = ['127.0.0.1'];
 $app['proxy'] = false;

--- a/lib/Transport/Application.php
+++ b/lib/Transport/Application.php
@@ -51,7 +51,7 @@ class Application extends \Silex\Application
         $app['monolog.level'] = \Monolog\Logger::ERROR;
         $app['redis.config'] = false; // array('host' => 'localhost', 'port' => 6379);
         $app['stats.config'] = ['enabled' => false];
-        $app['rate_limiting.config'] = ['enabled' => false, 'limit' => 150];
+        $app['rate_limiting.config'] = ['enabled' => false, 'limit' => 3];
         $app['proxy'] = false;
         $app['proxy_server.address'] = null;
 
@@ -165,7 +165,7 @@ class Application extends \Silex\Application
             if ($app['rate_limiting']->isEnabled()) {
                 $ip = $request->getClientIp();
                 if ($app['rate_limiting']->hasReachedLimit($ip)) {
-                    throw new HttpException(429, 'Rate limit of '.$app['rate_limiting']->getLimit().' requests per minute exceeded');
+                    throw new HttpException(429, 'Rate limit of '.$app['rate_limiting']->getLimit().' requests per second exceeded');
                 }
                 $app['rate_limiting']->increment($ip);
             }

--- a/web/docs.html
+++ b/web/docs.html
@@ -53,7 +53,7 @@
 
             <h3 id="rate-limiting">Rate Limiting</h3>
 
-            <p>The number of HTTP requests you can send to <code>transport.opendata.ch</code> is limited to 300 requests per minute per IP address. The number of remaining requests is sent back for your information in the HTTP response header <code>X-Rate-Limit-Remaining</code>. If you reach the maximum number of requests please <a href="mailto:transport@opendata.ch">contact us</a>, we are eager to hear your use case and discuss a solution.</p>
+            <p>The number of HTTP requests you can send to <code>transport.opendata.ch</code> is limited to 3 requests per second per IP address. The number of remaining requests is sent back for your information in the HTTP response header <code>X-Rate-Limit-Remaining</code>. If you reach the maximum number of requests please <a href="mailto:transport@opendata.ch">contact us</a>, we are eager to hear your use case and discuss a solution.</p>
 
             <h3 id="api-resources">API Resources</h3>
 


### PR DESCRIPTION
After discussions with SBB we will change the way we count the number of requests per IP address. Instead of per minute it will now be counted per second. We also agreed on 3 requests per second per IP address.