### PR TITLE
Prevent overlaps in pagination between future and past pages (#158)

### DIFF
--- a/lib/Transport/Application.php
+++ b/lib/Transport/Application.php
@@ -137,6 +137,7 @@ class Application extends \Silex\Application
 
         // Redis
         $redis = null;
+
         try {
             if ($app['redis.config']) {
                 $redis = new \Predis\Client($app['redis.config']);

--- a/lib/Transport/Entity/Coordinate.php
+++ b/lib/Transport/Entity/Coordinate.php
@@ -111,7 +111,7 @@ class Coordinate
     public static function setHAFAScoordinates($coordinate, $x, $y)
     {
         if ($y > $x) { // HAFAS bug, returns inverted lat/long
-          $coordinate->x = $y;
+            $coordinate->x = $y;
             $coordinate->y = $x;
         } else {
             $coordinate->x = $x;

--- a/lib/Transport/Entity/Location/Location.php
+++ b/lib/Transport/Entity/Location/Location.php
@@ -45,11 +45,11 @@ abstract class Location
      * Factory method to create an instance and extract the data from the given xml.
      *
      * @param \SimpleXMLElement $xml The item xml
-     * @param Location          $obj An object or null to create it
+     * @param self              $obj An object or null to create it
      *
-     * @return Location The created instance
+     * @return self The created instance
      */
-    public static function createFromXml(\SimpleXMLElement $xml, Location $obj = null)
+    public static function createFromXml(\SimpleXMLElement $xml, self $obj = null)
     {
         if (!is_object($obj)) {
             throw new \InvalidArgumentException('Argument must be an object');
@@ -69,12 +69,12 @@ abstract class Location
     /**
      * Factory method to create an instance and extract the data from the given JSON object.
      *
-     * @param object   $json The item JSON
-     * @param Location $obj  An object or null to create it
+     * @param object $json The item JSON
+     * @param self   $obj  An object or null to create it
      *
      * @return Location The created instance
      */
-    public static function createFromJson($json, Location $obj = null)
+    public static function createFromJson($json, self $obj = null)
     {
         if (!is_object($obj)) {
             throw new \InvalidArgumentException('Argument must be an object');

--- a/lib/Transport/Entity/Location/Station.php
+++ b/lib/Transport/Entity/Location/Station.php
@@ -44,7 +44,7 @@ class Station extends Location
         return $xml;
     }
 
-    public static function createStationFromXml(\SimpleXMLElement $xml, Station $obj = null)
+    public static function createStationFromXml(\SimpleXMLElement $xml, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();
@@ -59,7 +59,7 @@ class Station extends Location
     /**
      * @param object $json The item JSON
      */
-    public static function createStationFromJson($json, Station $obj = null)
+    public static function createStationFromJson($json, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();

--- a/lib/Transport/Entity/Schedule/Connection.php
+++ b/lib/Transport/Entity/Schedule/Connection.php
@@ -81,7 +81,7 @@ class Connection
      */
     public $sections;
 
-    public static function createFromXml(\SimpleXMLElement $xml, Connection $obj = null)
+    public static function createFromXml(\SimpleXMLElement $xml, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();
@@ -141,7 +141,7 @@ class Connection
         return $obj;
     }
 
-    public static function createFromJson($json, Connection $obj = null)
+    public static function createFromJson($json, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();

--- a/lib/Transport/Entity/Schedule/ConnectionQuery.php
+++ b/lib/Transport/Entity/Schedule/ConnectionQuery.php
@@ -71,7 +71,9 @@ class ConnectionQuery extends Query
         if ($this->page >= 0) {
             $request->setField('num', ($this->page + 1) * $this->limit);
         } else {
-            $request->setField('pre', abs($this->page) * $this->limit);
+            // in case of arrival, shift by 1 page because "pre" and "num" overlap by this much
+            $shift = $this->isArrivalTime ? 1 : 0;
+            $request->setField('pre', (abs($this->page) + $shift) * $this->limit);
         }
         $request->setField('show_delays', '1');
 

--- a/lib/Transport/Entity/Schedule/Journey.php
+++ b/lib/Transport/Entity/Schedule/Journey.php
@@ -87,7 +87,7 @@ class Journey
      */
     public $capacity2nd = null;
 
-    public static function createFromXml(\SimpleXMLElement $xml, \DateTime $date, Journey $obj = null)
+    public static function createFromXml(\SimpleXMLElement $xml, \DateTime $date, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();
@@ -161,7 +161,7 @@ class Journey
         return $obj;
     }
 
-    public static function createFromJson($json, Journey $obj = null)
+    public static function createFromJson($json, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();

--- a/lib/Transport/Entity/Schedule/Prognosis.php
+++ b/lib/Transport/Entity/Schedule/Prognosis.php
@@ -49,7 +49,7 @@ class Prognosis
      */
     public $capacity2nd;
 
-    public static function createFromXml(\SimpleXMLElement $xml, \DateTime $date, $isArrival, Prognosis $obj = null)
+    public static function createFromXml(\SimpleXMLElement $xml, \DateTime $date, $isArrival, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();
@@ -93,7 +93,7 @@ class Prognosis
         return $obj;
     }
 
-    public static function createFromJson($json, $stop, Prognosis $obj = null)
+    public static function createFromJson($json, $stop, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();

--- a/lib/Transport/Entity/Schedule/Section.php
+++ b/lib/Transport/Entity/Schedule/Section.php
@@ -43,7 +43,7 @@ class Section
      */
     public $arrival;
 
-    public static function createFromXml(\SimpleXMLElement $xml, \DateTime $date, Section $obj = null)
+    public static function createFromXml(\SimpleXMLElement $xml, \DateTime $date, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();
@@ -63,7 +63,7 @@ class Section
         return $obj;
     }
 
-    public static function createFromJson($json, Section $obj = null)
+    public static function createFromJson($json, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();

--- a/lib/Transport/Entity/Schedule/StationBoardJourney.php
+++ b/lib/Transport/Entity/Schedule/StationBoardJourney.php
@@ -22,7 +22,7 @@ class StationBoardJourney extends Journey
      *
      * @return StationBoardJourney
      */
-    public static function createStationBoardFromXml(\SimpleXMLElement $xml, \DateTime $date, StationBoardJourney $obj = null)
+    public static function createStationBoardFromXml(\SimpleXMLElement $xml, \DateTime $date, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();

--- a/lib/Transport/Entity/Schedule/Stop.php
+++ b/lib/Transport/Entity/Schedule/Stop.php
@@ -144,7 +144,7 @@ class Stop
         return $date;
     }
 
-    public static function createFromXml(\SimpleXMLElement $xml, \DateTime $date, Stop $obj = null)
+    public static function createFromXml(\SimpleXMLElement $xml, \DateTime $date, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();
@@ -197,7 +197,7 @@ class Stop
         return $obj;
     }
 
-    public static function createFromJson($json, Stop $obj = null)
+    public static function createFromJson($json, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();

--- a/lib/Transport/Entity/Schedule/Walk.php
+++ b/lib/Transport/Entity/Schedule/Walk.php
@@ -28,7 +28,7 @@ class Walk
     /**
      * @param \DateTime $date
      */
-    public static function createFromXml(\SimpleXMLElement $xml, $date, Walk $obj = null)
+    public static function createFromXml(\SimpleXMLElement $xml, $date, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();
@@ -39,7 +39,7 @@ class Walk
         return $obj;
     }
 
-    public static function createFromJson($json, Walk $obj = null)
+    public static function createFromJson($json, self $obj = null)
     {
         if (!$obj) {
             $obj = new self();


### PR DESCRIPTION
The currently utilized fahrplan.search.ch API treats the "num" and "pre"
parameters in a way such that they overlap by 4 connections:

```
    | num --->
   <--- pre |
-o-o-o-o-o-o-o-o-o-o-
            ^ time
```

In order to respect this, we now skip the first 4 previous items, i.e.
our page -1 starts at "pre=4".

@helbling Can you verify this is expected behavior and correct consumption of the API?

*An integration test verifying this (and preventing regression) would be great. But from what I can tell, no such tests (connecting to the external API) are in place yet, and I'm not familiar enough with the stack to introduce them.*