### PR TITLE
Adding support for transportations in connections again

### DIFF
--- a/lib/Transport/Entity/Schedule/ConnectionQuery.php
+++ b/lib/Transport/Entity/Schedule/ConnectionQuery.php
@@ -77,6 +77,10 @@ class ConnectionQuery extends Query
         }
         $request->setField('show_delays', '1');
 
+        if (count($this->transportations) > 0 && $this->transportations[0] != 'all') {
+            $request->setField('transportation_types', implode(',', $this->transportations));
+        }
+
         return $request;
     }
 

--- a/web/docs.html
+++ b/web/docs.html
@@ -230,8 +230,8 @@
                     <tr>
                         <td><code>transportations</code></td>
                         <td>optional</td>
-                        <td class="description">Transportation means; one or more of <code>ice_tgv_rj</code>, <code>ec_ic</code>, <code>ir</code>, <code>re_d</code>, <code>ship</code>, <code>s_sn_r</code>, <code>bus</code>, <code>cableway</code>, <code>arz_ext</code>, <code>tramway_underground</code></td>
-                        <td>transportations[]=ec_ic&amp;<br/>transportations[]=bus</td>
+                        <td class="description">Transportation means; one or more of <code>train</code>, <code>tram</code>, <code>bus</code>, <code>ship</code>, <code>cableway</code></td>
+                        <td>transportations[]=tram&amp;<br/>transportations[]=bus</td>
                     </tr>
                     <tr>
                         <td><code>limit</code></td>


### PR DESCRIPTION
Adding support for transportations again. Reviews welcome, looking at merging and deploying it next week.

> We have introduced a new parameter transportation_types on the timetable.search.ch API.
> See documentation here: https://fahrplan.search.ch/api/help#route
> 
> Note that not all the filters the transport api supported in the past work, as we don't think the very fine-graned train filters are ever needed.
> 
> https://github.com/OpendataCH/Transport/issues/182#issuecomment-389427093

Fixes https://github.com/OpendataCH/Transport/issues/164.