### PR TITLE
Support old 'transportations' parameters for StationBoard and Connection

### DIFF
--- a/lib/Transport/Entity/Schedule/ConnectionQuery.php
+++ b/lib/Transport/Entity/Schedule/ConnectionQuery.php
@@ -78,7 +78,7 @@ class ConnectionQuery extends Query
         $request->setField('show_delays', '1');
 
         if (count($this->transportations) > 0 && $this->transportations[0] != 'all') {
-            $request->setField('transportation_types', implode(',', $this->transportations));
+            $request->setField('transportation_types', implode(',', Transportations::transformDeprecatedTypes($this->transportations)));
         }
 
         return $request;

--- a/lib/Transport/Entity/Schedule/StationBoardQuery.php
+++ b/lib/Transport/Entity/Schedule/StationBoardQuery.php
@@ -42,9 +42,9 @@ class StationBoardQuery extends Query
         $request->setField('limit', $this->maxJourneys);
         $request->setField('show_tracks', '1');
         $request->setField('show_subsequent_stops', '1');
-
+        
         if (count($this->transportations) > 0 && $this->transportations[0] != 'all') {
-            $request->setField('transportation_types', implode(',', $this->transportations));
+            $request->setField('transportation_types', implode(',', Transportations::transformDeprecatedTypes($this->transportations)));
         }
 
         return $request;

--- a/lib/Transport/Entity/Schedule/StationBoardQuery.php
+++ b/lib/Transport/Entity/Schedule/StationBoardQuery.php
@@ -42,7 +42,7 @@ class StationBoardQuery extends Query
         $request->setField('limit', $this->maxJourneys);
         $request->setField('show_tracks', '1');
         $request->setField('show_subsequent_stops', '1');
-        
+
         if (count($this->transportations) > 0 && $this->transportations[0] != 'all') {
             $request->setField('transportation_types', implode(',', Transportations::transformDeprecatedTypes($this->transportations)));
         }

--- a/lib/Transport/Entity/Transportations.php
+++ b/lib/Transport/Entity/Transportations.php
@@ -77,11 +77,10 @@ class Transportations
         return $dec;
     }
 
-
     /**
      * Converts old transportations types into new generic types.
      *
-     * @param array    $transportations A list of transportations
+     * @param array $transportations A list of transportations
      *
      * @return array A list of transportations where old types have been replaced by new types
      */

--- a/lib/Transport/Entity/Transportations.php
+++ b/lib/Transport/Entity/Transportations.php
@@ -23,6 +23,23 @@ class Transportations
         'groups'              => 32768, // 2^15
     ];
 
+    private static $deprecatedTransportations = [
+        'ice_tgv_rj'          => 'train',
+        'ec_ic'               => 'train',
+        'ir'                  => 'train',
+        're_d'                => 'train',
+        'ship'                => 'ship',
+        's_sn_r'              => 'train',
+        'bus'                 => 'bus',
+        'cableway'            => 'cableway',
+        'arz_ext'             => 'train',
+        'tramway_underground' => 'tram',
+        'tramway'             => 'tram',
+        'direct'              => 'train',
+        'direct_sleeper'      => 'train',
+        'direct_couchette'    => 'train',
+    ];
+
     /**
      * Converts a list of transportation strings into a bitmask accepted by the SBB.
      *
@@ -58,5 +75,27 @@ class Transportations
         }
 
         return $dec;
+    }
+
+
+    /**
+     * Converts old transportations types into new generic types.
+     *
+     * @param array    $transportations A list of transportations
+     *
+     * @return array A list of transportations where old types have been replaced by new types
+     */
+    public static function transformDeprecatedTypes($transportations = [])
+    {
+        foreach (self::$deprecatedTransportations as $oldTrsp => $newTrsp) {
+            $transportations = array_replace($transportations,
+                array_fill_keys(
+                    array_keys($transportations, $oldTrsp),
+                    $newTrsp
+                )
+            );
+        }
+
+        return array_unique($transportations);
     }
 }

--- a/test/Transport/Test/Entity/TransportationsTest.php
+++ b/test/Transport/Test/Entity/TransportationsTest.php
@@ -54,4 +54,18 @@ class TransportationsTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(1023, Transportations::reduceTransportationsDec($transportations, 10));
     }
+
+    public function testTransformDeprecatedTypes()
+    {
+        $transportations = ['ice_tgv_rj'];
+
+        $this->assertSame(['train'], Transportations::transformDeprecatedTypes($transportations));
+    }
+
+    public function testTransformDeprecatedTypesTrainBus()
+    {
+        $transportations = ['ice_tgv_rj','bus','ec_ic'];
+
+        $this->assertSame(['train','bus'], Transportations::transformDeprecatedTypes($transportations));
+    }
 }

--- a/test/Transport/Test/Entity/TransportationsTest.php
+++ b/test/Transport/Test/Entity/TransportationsTest.php
@@ -64,8 +64,8 @@ class TransportationsTest extends \PHPUnit_Framework_TestCase
 
     public function testTransformDeprecatedTypesTrainBus()
     {
-        $transportations = ['ice_tgv_rj','bus','ec_ic'];
+        $transportations = ['ice_tgv_rj', 'bus', 'ec_ic'];
 
-        $this->assertSame(['train','bus'], Transportations::transformDeprecatedTypes($transportations));
+        $this->assertSame(['train', 'bus'], Transportations::transformDeprecatedTypes($transportations));
     }
 }


### PR DESCRIPTION
Hi @fabian!

I followed the suggestion you did in issue #182 to map the old types to the new `transportation` types because we have a lot of devices that are currently not showing any train informations anymore and the deployment of our update will take some time. If you accept this pull request it will be more backwards compatible.

By the way we love this API! ;-)

Cheers!
Florent 