### PR TITLE
Retrieve train number from *Z parameter

### DIFF
--- a/lib/Transport/Entity/Schedule/Journey.php
+++ b/lib/Transport/Entity/Schedule/Journey.php
@@ -167,9 +167,9 @@ class Journey
             $obj = new self();
         }
 
-        if (isset($json->number)) {
-            $obj->name = $json->number;
-            $obj->number = $json->number;
+        if (isset($json->{'*Z'})) {
+            $obj->name = $json->{'*Z'};
+            $obj->number = $json->{'*Z'};
         }
         if (isset($json->{'*L'})) {
             $obj->number = $json->{'*L'};


### PR DESCRIPTION
As mentioned in #209, the upstream api has been updated and the parameter number is not given anymore.
The alternative is to use the parameter "*Z".